### PR TITLE
Updated Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -57,8 +57,8 @@ Issue the following terminal command: `brew cask install aerial`
 
 ## Troubleshooting
 
-- Black screen / cannot stream: If you run a reverse firewall, such as Little Snitch or Hands Off!, be sure the application 'ScreenSaverEngine.app' is not being blocked access to \*.phobos.apple.com.
-- Black preview / cannot pre-download: If you run a reverse firewall, such as Little Snitch or Hands Off!, be sure the application 'System Preferences.app' is not being blocked access to \*.phobos.apple.com.
+- Black screen / cannot stream: If you run a reverse firewall, such as Little Snitch or Hands Off!, be sure the application 'ScreenSaverEngine.app' is not being blocked access to *.phobos.apple.com.
+- Black preview / cannot pre-download: If you run a reverse firewall, such as Little Snitch or Hands Off!, be sure the application 'System Preferences.app' is not being blocked access to *.phobos.apple.com.
 
 ## License
 [MIT License](https://raw.githubusercontent.com/JohnCoates/Aerial/master/LICENSE)

--- a/Readme.md
+++ b/Readme.md
@@ -57,7 +57,8 @@ Issue the following terminal command: `brew cask install aerial`
 
 ## Troubleshooting
 
-- Black screen: Try disabling Little Snitch, or try the latest beta release from [Aerial Releases](https://github.com/JohnCoates/Aerial/releases/).
+- Black screen / cannot stream: If you run a reverse firewall, such as Little Snitch or Hands Off!, be sure the application 'ScreenSaverEngine.app' is not being blocked access to \*.phobos.apple.com.
+- Black preview / cannot pre-download: If you run a reverse firewall, such as Little Snitch or Hands Off!, be sure the application 'System Preferences.app' is not being blocked access to \*.phobos.apple.com.
 
 ## License
 [MIT License](https://raw.githubusercontent.com/JohnCoates/Aerial/master/LICENSE)

--- a/Readme.md
+++ b/Readme.md
@@ -57,8 +57,8 @@ Issue the following terminal command: `brew cask install aerial`
 
 ## Troubleshooting
 
-- Black screen / cannot stream: If you run a reverse firewall, such as Little Snitch or Hands Off!, be sure the application 'ScreenSaverEngine.app' is not being blocked access to *.phobos.apple.com.
-- Black preview / cannot pre-download: If you run a reverse firewall, such as Little Snitch or Hands Off!, be sure the application 'System Preferences.app' is not being blocked access to *.phobos.apple.com.
+- Black screen / cannot stream: If you run a reverse firewall, such as Little Snitch or Hands Off!, be sure the application 'ScreenSaverEngine.app' is not being blocked access to *.phobos.apple.com and *.phobos.apple.com.edgesuite.net.
+- Black preview / cannot cache: If you run a reverse firewall, such as Little Snitch or Hands Off!, be sure the application 'System Preferences.app' is not being blocked access to *.phobos.apple.com and *.phobos.apple.com.edgesuite.net.
 
 ## License
 [MIT License](https://raw.githubusercontent.com/JohnCoates/Aerial/master/LICENSE)


### PR DESCRIPTION
The black screens are caused by reverse firewalls. Two services are needed to be allowed access. 'System Preferences.app' is for pre-fetching and the preview. 'ScreenSaverEngine.app' for streaming while running at screen save time.