### PR TITLE
Default Screen Saver as Desktop Background

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -35,6 +35,17 @@ If Aerial.saver could not be opened, place Aerial.saver in ~/Library/Screen Save
 
 ![Screenshot](https://cloud.githubusercontent.com/assets/499192/10754102/c58cc076-7c95-11e5-9579-4275740ba339.png)
 
+## Optional: Set Aerial as Moving Desktop Background
+
+1. Open Terminal 
+2. Paste or type below command(sets your Default Screen Saver as Desktop Background): 
+<pre>
+  cd /System/Library/Frameworks/ScreenSaver.framework/Resources;
+  ./ScreenSaverEngine.app/Contents/MacOS/ScreenSaverEngine -background
+</pre>
+3. Minimize Terminal window and enjoy your day. 
+4. To stop: close terminal or it default terminates when you put your computer to sleep/shut down. 
+
 ## Uninstallation
 
 There are three options to uninstall Aerial from your Mac.


### PR DESCRIPTION
Battery consumption seemed significantly less than playing a youtube video on chrome.

Have enjoyed the application for the past 6 months.
Glad I finally have something to contribute.
Found the command in this post:
http://www.techradar.com/how-to/computing/apple/easy-mac-hacks-set-screen-saver-as-desktop-background-1305622
Worked perfect on my Mac OSX Sierra 10.12.3
Specs: Processor 2.9 GHz; Memory 8 GB Ram; Graphics Intel HD 4000;

I tried to stay consistent to the current Readme format.
Let me know if you want any improvements to the commit.
Or if you have any questions.

Cheers, Michael Dimmitt