### PR TITLE
Crossfade

### DIFF
--- a/Aerial/Source/Models/ManifestLoader.swift
+++ b/Aerial/Source/Models/ManifestLoader.swift
@@ -13,13 +13,13 @@ typealias manifestLoadCallback = ([AerialVideo]) -> (Void)
 
 class ManifestLoader {
     static let instance: ManifestLoader = ManifestLoader()
-    
+
     lazy var preferences = Preferences.sharedInstance
     var callbacks = [manifestLoadCallback]()
     var loadedManifest = [AerialVideo]()
     var playedVideos = [AerialVideo]()
-    var offlineMode: Bool = false
-    
+    var offlineMode: Bool = true
+
     func addCallback(_ callback:@escaping manifestLoadCallback) {
         if loadedManifest.count > 0 {
             callback(loadedManifest)
@@ -27,17 +27,17 @@ class ManifestLoader {
             callbacks.append(callback)
         }
     }
-    
+
     func randomVideo() -> AerialVideo? {
         let shuffled = loadedManifest.shuffled()
         for video in shuffled {
             let inRotation = preferences.videoIsInRotation(videoID: video.id)
-            
+
             if !inRotation {
                 debugLog("video is disabled: \(video)")
                 continue
             }
-            
+
             // check if we're in offline mode
             if offlineMode == true {
                 if video.isAvailableOffline == false {
@@ -47,11 +47,11 @@ class ManifestLoader {
             
             return video
         }
-        
+
         // nothing available??? return first thing we find
         return shuffled.first
     }
-    
+
     init() {
         // start loading right away!
         let completionHandler = { (data: Data?, response: URLResponse?, error: Error?) -> Void in
@@ -60,18 +60,18 @@ class ManifestLoader {
                 self.loadSavedManifest()
                 return
             }
-            
+
             guard let data = data else {
                 NSLog("Couldn't load manifest!")
                 self.loadSavedManifest()
                 return
             }
             self.preferences.manifest = data
-            
+
             DispatchQueue.main.async(execute: { () -> Void in
                 self.readJSONFromData(data)
             })
-            
+
         }
         let apiURL = "http://a1.phobos.apple.com/us/r1000/000/Features/atv/AutumnResources/videos/entries.json"
         guard let url = URL(string: apiURL) else {
@@ -83,69 +83,69 @@ class ManifestLoader {
         let task = session.dataTask(with: url, completionHandler: completionHandler)
         task.resume()
     }
-    
+
     func loadSavedManifest() {
         guard let savedJSON = preferences.manifest else {
             debugLog("Couldn't find saved manifest")
             return
         }
-        
+
         offlineMode = true
         readJSONFromData(savedJSON)
     }
-    
+
     func readJSONFromData(_ data: Data) {
         var videos = [AerialVideo]()
-        
+
         do {
             let options = JSONSerialization.ReadingOptions.allowFragments
             let batches = try JSONSerialization.jsonObject(with: data,
                                                            options: options) as! Array<NSDictionary>
-            
+
             for batch: NSDictionary in batches {
                 let assets = batch["assets"] as! Array<NSDictionary>
-                
+
                 for item in assets {
                     let url = item["url"] as! String
                     let name = item["accessibilityLabel"] as! String
                     let timeOfDay = item["timeOfDay"] as! String
                     let id = item["id"] as! String
                     let type = item["type"] as! String
-                    
+
                     if type != "video" {
                         continue
                     }
-                    
+
                     let video = AerialVideo(id: id,
                                             name: name,
                                             type: type,
                                             timeOfDay: timeOfDay,
                                             url: url)
-                    
+
                     videos.append(video)
-                    
+
                     checkContentLength(video)
                 }
             }
-            
+
             self.loadedManifest = videos
         } catch {
             NSLog("Aerial: Error retrieving content listing.")
             return
         }
     }
-    
+
     func checkContentLength(_ video: AerialVideo) {
         let config = URLSessionConfiguration.default
         let session = URLSession(configuration: config)
         let request = NSMutableURLRequest(url: video.url as URL)
         request.httpMethod = "HEAD"
-        
+
         let task = session.dataTask(with: request as URLRequest,
                                     completionHandler: {
                                         data, response, error in
             video.contentLengthChecked = true
-            
+
             if let error = error {
                 NSLog("error fetching content length: \(error)")
                 DispatchQueue.main.async(execute: { () -> Void in
@@ -153,21 +153,21 @@ class ManifestLoader {
                 })
                 return
             }
-            
+
             guard let response = response else {
                 return
             }
-            
+
             video.contentLength = Int(response.expectedContentLength)
 //            NSLog("content length: \(response.expectedContentLength)")
             DispatchQueue.main.async(execute: { () -> Void in
                 self.receivedContentLengthResponse()
             })
-        }) 
-        
+        })
+
         task.resume()
     }
-    
+
     func receivedContentLengthResponse() {
         // check if content length on all videos has been checked
         for video in loadedManifest {
@@ -175,13 +175,13 @@ class ManifestLoader {
                 return
             }
         }
-        
+
         filterVideoAndProcessCallbacks()
     }
-    
+
     func filterVideoAndProcessCallbacks() {
         let unfiltered = loadedManifest
-        
+
         var filtered = [AerialVideo]()
         for video in unfiltered {
             // offline? eror? just put it through
@@ -189,7 +189,7 @@ class ManifestLoader {
                 filtered.append(video)
                 continue
             }
-            
+
             // check to see if we find another video with the same content length
             var isDuplicate = false
             for videoCheck in filtered {
@@ -197,31 +197,31 @@ class ManifestLoader {
                     isDuplicate = true
                     continue
                 }
-                
+
                 if videoCheck.name != video.name {
                     continue
                 }
-                
+
                 if videoCheck.timeOfDay != video.timeOfDay {
                     continue
                 }
-                
+
                 if videoCheck.contentLength == video.contentLength {
 //                    NSLog("removing duplicate video \(videoCheck.name) \(videoCheck.timeOfDay)")
                     isDuplicate = true
                     break
                 }
             } // dupe check
-            
+
             if isDuplicate == true {
                 continue
             }
-            
+
             filtered.append(video)
         }
-        
+
         loadedManifest = filtered
-        
+
         // callbacks
         for callback in self.callbacks {
             callback(filtered)

--- a/Aerial/Source/Views/AerialView.swift
+++ b/Aerial/Source/Views/AerialView.swift
@@ -196,6 +196,37 @@ class AerialView: ScreenSaverView {
     
     // MARK: - Playing Videos
     
+    func playWithFade() {
+      self.player?.play()
+      // self.playerLayer.opacity = 0.0
+      // fade in
+      let inImation = CAKeyframeAnimation()
+      inImation.keyPath = "opacity"
+      inImation.keyTimes = [0,1]
+      inImation.values = [0,1]
+      inImation.duration = 3
+      inImation.fillMode = kCAFillModeBackwards
+      inImation.beginTime = CACurrentMediaTime()+1;
+      self.playerLayer?.add(inImation, forKey: "inOpacity")
+
+      // let currentPlayerItem = self.player?.currentItem
+      let duration = self.player?.currentItem?.asset.duration
+      let offset = CMTimeGetSeconds(duration!)
+      NSLog("\nclip length is \(offset)\n\n")
+      // var currentTime = AVPlayer.currentTime()
+
+      let outImation = CAKeyframeAnimation()
+      outImation.keyPath = "opacity"
+      outImation.keyTimes = [1,0]
+      outImation.values = [0,1]
+      outImation.duration = 3
+      outImation.fillMode = kCAFillModeForwards
+      outImation.isRemovedOnCompletion = false
+      outImation.beginTime = CACurrentMediaTime()+offset-3.5;
+      self.playerLayer?.add(outImation, forKey: "outOpacity")
+    }
+
+    
     func playNextVideo() {
         let notificationCenter = NotificationCenter.default
         
@@ -229,8 +260,9 @@ class AerialView: ScreenSaverView {
         }
         let videoURL = video.url
         
-        let asset = CachedOrCachingAsset(videoURL)
-//        let asset = AVAsset(URL: videoURL)
+        // let asset = CachedOrCachingAsset(videoURL)
+        let asset = AVAsset(url: videoURL)
+        // assets from CachedOrCaching have undefined duration which is needed start the fade out
         
         let item = AVPlayerItem(asset: asset)
         
@@ -238,7 +270,7 @@ class AerialView: ScreenSaverView {
         
         debugLog("playing video: \(video.url)")
         if player.rate == 0 {
-            player.play()
+            playWithFade()
         }
         
         guard let currentItem = player.currentItem else {

--- a/Aerial/Source/Views/AerialView.swift
+++ b/Aerial/Source/Views/AerialView.swift
@@ -13,308 +13,371 @@ import AVKit
 
 @objc(AerialView)
 class AerialView: ScreenSaverView {
-    var playerLayer: AVPlayerLayer!
-    var preferencesController: PreferencesWindowController?
-    static var players: [AVPlayer] = [AVPlayer]()
-    static var previewPlayer: AVPlayer?
-    static var previewView: AerialView?
+  var playerLayer: AVPlayerLayer!
+  var playerLayerBack: AVPlayerLayer!
+  var preferencesController: PreferencesWindowController?
+  static var players: [AVPlayer] = [AVPlayer]()
+  static var previewPlayer: AVPlayer?
+  static var previewView: AerialView?
 
-    var player: AVPlayer?
+  var player: AVPlayer?
+  var playerBack: AVPlayer?
 
-    static var sharingPlayers: Bool {
-        let preferences = Preferences.sharedInstance
-        return !preferences.differentAerialsOnEachDisplay
-    }
+  var currentPlayerIsFrontPlayer: Bool = false
 
-    static var sharedViews: [AerialView] = []
+  static var sharingPlayers: Bool {
+    let preferences = Preferences.sharedInstance
+    return !preferences.differentAerialsOnEachDisplay
+  }
 
-    // MARK: - Shared Player
+  static var sharedViews: [AerialView] = []
 
-    static var singlePlayerAlreadySetup: Bool = false
-    class var sharedPlayer: AVPlayer {
-        struct Static {
-            static let instance: AVPlayer = AVPlayer()
-            static var _player: AVPlayer?
-            static var player: AVPlayer {
-                if let activePlayer = _player {
-                    return activePlayer
-                }
+  // MARK: - Shared Player
 
-                _player = AVPlayer()
-                return _player!
-            }
+  static var singlePlayerAlreadySetup: Bool = false
+  class var sharedPlayer: AVPlayer {
+    struct Static {
+      static let instance: AVPlayer = AVPlayer()
+      static var _player: AVPlayer?
+      static var player: AVPlayer {
+        if let activePlayer = _player {
+          return activePlayer
         }
 
-        return Static.player
-    }
-
-    // MARK: - Init / Setup
-
-    override init?(frame: NSRect, isPreview: Bool) {
-        super.init(frame: frame, isPreview: isPreview)
-
-        self.animationTimeInterval = 1.0 / 30.0
-        setup()
-    }
-
-    required init?(coder: NSCoder) {
-        super.init(coder: coder)
-        setup()
-    }
-
-    deinit {
-        debugLog("deinit AerialView")
-        NotificationCenter.default.removeObserver(self)
-
-        // set player item to nil if not preview player
-        if player != AerialView.previewPlayer {
-            player?.rate = 0
-            player?.replaceCurrentItem(with: nil)
-        }
-
-        guard let player = self.player else {
-            return
-        }
-
-        // Remove from player index
-
-        let indexMaybe = AerialView.players.index(of: player)
-
-        guard let index = indexMaybe else {
-            return
-        }
-
-        AerialView.players.remove(at: index)
-    }
-
-    func setupPlayerLayer(withPlayer player: AVPlayer) {
-        self.layer = CALayer()
-        guard let layer = self.layer else {
-            NSLog("Aerial Errror: Couldn't create CALayer")
-            return
-        }
-        self.wantsLayer = true
-        layer.backgroundColor = NSColor.black.cgColor
-        layer.needsDisplayOnBoundsChange = true
-        layer.frame = self.bounds
-//        layer.backgroundColor = NSColor.greenColor().CGColor
-
-        debugLog("setting up player layer with frame: \(self.bounds) / \(self.frame)")
-
-        playerLayer = AVPlayerLayer(player: player)
-        if #available(OSX 10.10, *) {
-            playerLayer.videoGravity = AVLayerVideoGravityResizeAspectFill
-        }
-        playerLayer.autoresizingMask = [CAAutoresizingMask.layerWidthSizable, CAAutoresizingMask.layerHeightSizable]
-        playerLayer.frame = layer.bounds
-        layer.addSublayer(playerLayer)
-    }
-
-    func setup() {
-        var localPlayer: AVPlayer?
-
-        let notPreview = !isPreview
-
-        if notPreview {
-            // check if we should share preview's player
-            let noPlayers = (AerialView.players.count == 0)
-            let previewPlayerExists = (AerialView.previewPlayer != nil)
-            if noPlayers && previewPlayerExists {
-                localPlayer = AerialView.previewPlayer
-            }
-        } else {
-            AerialView.previewView = self
-        }
-
-        if AerialView.sharingPlayers {
-            AerialView.sharedViews.append(self)
-        }
-
-        if localPlayer == nil {
-            if AerialView.sharingPlayers {
-                if AerialView.previewPlayer != nil {
-                    localPlayer = AerialView.previewPlayer
-                } else {
-                    localPlayer = AerialView.sharedPlayer
-                }
-            } else {
-                localPlayer = AVPlayer()
-            }
-        }
-
-        guard let player = localPlayer else {
-            NSLog("Aerial Error: Couldn't create AVPlayer!")
-            return
-        }
-
-        self.player = player
-
-        if self.isPreview {
-            AerialView.previewPlayer = player
-        } else if !AerialView.sharingPlayers {
-            // add to player list
-            AerialView.players.append(player)
-        }
-
-        setupPlayerLayer(withPlayer: player)
-
-        if AerialView.sharingPlayers && AerialView.singlePlayerAlreadySetup {
-            self.playerLayer.player = AerialView.sharedViews[0].player
-            return
-        }
-
-        AerialView.singlePlayerAlreadySetup = true
-
-        ManifestLoader.instance.addCallback { videos in
-            self.playNextVideo()
-        }
-    }
-
-    // MARK: - AVPlayerItem Notifications
-
-    func playerItemFailedtoPlayToEnd(_ aNotification: Notification) {
-        NSLog("AVPlayerItemFailedToPlayToEndTimeNotification \(aNotification)")
-
-        playNextVideo()
-    }
-
-    func playerItemNewErrorLogEntryNotification(_ aNotification: Notification) {
-        NSLog("AVPlayerItemNewErrorLogEntryNotification \(aNotification)")
-    }
-
-    func playerItemPlaybackStalledNotification(_ aNotification: Notification) {
-        NSLog("AVPlayerItemPlaybackStalledNotification \(aNotification)")
-    }
-
-    func playerItemDidReachEnd(_ aNotification: Notification) {
-        debugLog("played did reach end")
-        debugLog("notification: \(aNotification)")
-        playNextVideo()
-
-        debugLog("playing next video for player \(player)")
-    }
-
-    // MARK: - Playing Videos
-
-    func playWithFade(clipEnd: Double) {
-      self.player?.play()
-      // self.playerLayer.opacity = 0.0
-      // fade in
-      let inImation = CAKeyframeAnimation()
-      inImation.keyPath = "opacity"
-      inImation.keyTimes = [0,1]
-      inImation.values = [0,1]
-      inImation.duration = 3
-      inImation.fillMode = kCAFillModeBackwards
-      inImation.beginTime = CACurrentMediaTime()+1;
-      self.playerLayer?.add(inImation, forKey: "inOpacity")
-
-      // let currentPlayerItem = self.player?.currentItem
-      // let duration = self.player?.currentItem?.asset.duration
-      // let offset = CMTimeGetSeconds(duration!)
-      // NSLog("\nclip length is \(offset)\n\n")
-      // var currentTime = AVPlayer.currentTime()
-
-      if clipEnd != 0 {
-        // NSLog("\n\n clipEnd \(clipEnd) \n\n")
-        let outImation = CAKeyframeAnimation()
-        outImation.keyPath = "opacity"
-        outImation.keyTimes = [1,0]
-        outImation.values = [0,1]
-        outImation.duration = 3
-        outImation.fillMode = kCAFillModeForwards
-        outImation.isRemovedOnCompletion = false
-        outImation.beginTime = CACurrentMediaTime()+clipEnd-3.5;
-        self.playerLayer?.add(outImation, forKey: "outOpacity")
+        _player = AVPlayer()
+        return _player!
       }
     }
 
+    return Static.player
+  }
 
-    func playNextVideo() {
-        let notificationCenter = NotificationCenter.default
+  // MARK: - Init / Setup
 
-        // remove old entries
-        notificationCenter.removeObserver(self)
+  override init?(frame: NSRect, isPreview: Bool) {
+    super.init(frame: frame, isPreview: isPreview)
 
-        let player = AVPlayer()
-        // play another video
-        let oldPlayer = self.player
-        self.player = player
-        self.playerLayer.player = self.player
+    self.animationTimeInterval = 1.0 / 30.0
+    setup()
+  }
 
-        if self.isPreview {
-            AerialView.previewPlayer = player
-        }
+  required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    setup()
+  }
 
-        debugLog("Setting player for all player layers in \(AerialView.sharedViews)")
-        for view in AerialView.sharedViews {
-            view.playerLayer.player = player
-        }
+  deinit {
+    debugLog("deinit AerialView")
+    NotificationCenter.default.removeObserver(self)
 
-        if oldPlayer == AerialView.previewPlayer {
-            AerialView.previewView?.playerLayer.player = self.player
-        }
-
-        let randomVideo = ManifestLoader.instance.randomVideo()
-
-        guard let video = randomVideo else {
-            NSLog("Aerial: Error grabbing random video!")
-            return
-        }
-        let videoURL = video.url
-
-        let asset = CachedOrCachingAsset(videoURL)
-        let dummyAsset = AVAsset(url: videoURL)
-        let fadeOutTime = CMTimeGetSeconds(dummyAsset.duration)
-
-        let item = AVPlayerItem(asset: asset)
-
-        player.replaceCurrentItem(with: item)
-
-        debugLog("playing video: \(video.url)")
-        if player.rate == 0 {
-            playWithFade(clipEnd: fadeOutTime)
-        }
-
-        guard let currentItem = player.currentItem else {
-            NSLog("Aerial Error: No current item!")
-            return
-        }
-
-        debugLog("observing current item \(currentItem)")
-        notificationCenter.addObserver(self,
-                                       selector: #selector(AerialView.playerItemDidReachEnd(_:)),
-                                       name: NSNotification.Name.AVPlayerItemDidPlayToEndTime,
-                                       object: currentItem)
-        notificationCenter.addObserver(self,
-                                       selector: #selector(AerialView.playerItemNewErrorLogEntryNotification(_:)),
-                                       name: NSNotification.Name.AVPlayerItemNewErrorLogEntry,
-                                       object: currentItem)
-        notificationCenter.addObserver(self,
-                                       selector: #selector(AerialView.playerItemFailedtoPlayToEnd(_:)),
-                                       name: NSNotification.Name.AVPlayerItemFailedToPlayToEndTime,
-                                       object: currentItem)
-        notificationCenter.addObserver(self,
-                                       selector: #selector(AerialView.playerItemPlaybackStalledNotification(_:)),
-                                       name: NSNotification.Name.AVPlayerItemPlaybackStalled,
-                                       object: currentItem)
-        player.actionAtItemEnd = AVPlayerActionAtItemEnd.none
+    // set player item to nil if not preview player
+    if player != AerialView.previewPlayer {
+      player?.rate = 0
+      player?.replaceCurrentItem(with: nil)
     }
 
-    // MARK: - Preferences
-
-    override func hasConfigureSheet() -> Bool {
-        return true
+    guard let player = self.player else {
+      return
     }
 
-    override func configureSheet() -> NSWindow? {
-        if let controller = preferencesController {
-            return controller.window
+    // Remove from player index
+
+    let indexMaybe = AerialView.players.index(of: player)
+
+    guard let index = indexMaybe else {
+      return
+    }
+
+    AerialView.players.remove(at: index)
+  }
+
+  func setupPlayerLayers(withPlayer player: AVPlayer, andBackPlayer playerBack: AVPlayer) {
+
+    if self.layer == nil {
+      self.layer = CALayer()
+    }
+    guard let layer = self.layer else {
+      NSLog("Aerial Errror: Couldn't create CALayer")
+      return
+    }
+    self.wantsLayer = true
+    layer.backgroundColor = NSColor.black.cgColor
+    layer.needsDisplayOnBoundsChange = true
+    layer.frame = self.bounds
+    //        layer.backgroundColor = NSColor.greenColor().CGColor
+
+    debugLog("setting up player layer with frame: \(self.bounds) / \(self.frame)")
+
+    playerLayerBack = AVPlayerLayer(player: playerBack)
+    if #available(OSX 10.10, *) {
+      playerLayerBack.videoGravity = AVLayerVideoGravityResizeAspectFill
+    }
+    playerLayerBack.autoresizingMask = [CAAutoresizingMask.layerWidthSizable, CAAutoresizingMask.layerHeightSizable]
+    playerLayerBack.frame = layer.bounds
+    playerLayerBack.opacity = 1.0
+    layer.addSublayer(playerLayerBack)
+
+    playerLayer = AVPlayerLayer(player: player)
+    if #available(OSX 10.10, *) {
+      playerLayer.videoGravity = AVLayerVideoGravityResizeAspectFill
+    }
+    playerLayer.autoresizingMask = [CAAutoresizingMask.layerWidthSizable, CAAutoresizingMask.layerHeightSizable]
+    playerLayer.frame = layer.bounds
+    playerLayer.opacity = 0.5
+    layer.addSublayer(playerLayer)
+
+
+
+  }
+
+  func setup() {
+    var localPlayer: AVPlayer?
+
+    let notPreview = !isPreview
+
+    if notPreview {
+      // check if we should share preview's player
+      let noPlayers = (AerialView.players.count == 0)
+      let previewPlayerExists = (AerialView.previewPlayer != nil)
+      if noPlayers && previewPlayerExists {
+        localPlayer = AerialView.previewPlayer
+      }
+    } else {
+      AerialView.previewView = self
+    }
+
+    if AerialView.sharingPlayers {
+      AerialView.sharedViews.append(self)
+    }
+
+    if localPlayer == nil {
+      if AerialView.sharingPlayers {
+        if AerialView.previewPlayer != nil {
+          localPlayer = AerialView.previewPlayer
+        } else {
+          localPlayer = AerialView.sharedPlayer
         }
-
-        let controller = PreferencesWindowController(windowNibName: "PreferencesWindow")
-
-        preferencesController = controller
-        return controller.window
+      } else {
+        localPlayer = AVPlayer()
+      }
     }
+
+    guard let player = localPlayer else {
+      NSLog("Aerial Error: Couldn't create AVPlayer!")
+      return
+    }
+
+    self.player = player
+
+    if self.isPreview {
+      AerialView.previewPlayer = player
+    } else if !AerialView.sharingPlayers {
+      // add to player list
+      AerialView.players.append(player)
+    }
+
+
+    let localPlayerBack = AVPlayer()
+    self.playerBack = localPlayerBack
+    setupPlayerLayers(withPlayer: player, andBackPlayer: localPlayerBack)
+
+
+
+    if AerialView.sharingPlayers && AerialView.singlePlayerAlreadySetup {
+      self.playerLayer.player = AerialView.sharedViews[0].player
+      return
+    }
+
+    AerialView.singlePlayerAlreadySetup = true
+
+    ManifestLoader.instance.addCallback { videos in
+      self.playNextVideo()
+    }
+  }
+
+  // MARK: - AVPlayerItem Notifications
+
+  func playerItemFailedtoPlayToEnd(_ aNotification: Notification) {
+    NSLog("AVPlayerItemFailedToPlayToEndTimeNotification \(aNotification)")
+
+    playNextVideo()
+  }
+
+  func playerItemNewErrorLogEntryNotification(_ aNotification: Notification) {
+    NSLog("AVPlayerItemNewErrorLogEntryNotification \(aNotification)")
+  }
+
+  func playerItemPlaybackStalledNotification(_ aNotification: Notification) {
+    NSLog("AVPlayerItemPlaybackStalledNotification \(aNotification)")
+  }
+
+  func playerItemDidReachEnd(_ aNotification: Notification) {
+    debugLog("played did reach end")
+    debugLog("notification: \(aNotification)")
+//    playNextVideo()
+
+    debugLog("playing next video for player \(player)")
+  }
+
+  // MARK: - Playing Videos
+
+
+  func fadeLayerIn(layerToFade: AVPlayerLayer) {
+    let inImation = CAKeyframeAnimation()
+    inImation.keyPath = "opacity"
+    inImation.keyTimes = [0,1]
+    inImation.values = [0,1]
+    inImation.duration = 3
+    inImation.fillMode = kCAFillModeBoth
+    inImation.isRemovedOnCompletion = false
+    inImation.beginTime = CACurrentMediaTime()+0.5
+    layerToFade.add(inImation, forKey: "inOpacity")
+  }
+
+  func fadeLayerOut(layerToFade: AVPlayerLayer) {
+    let outImation = CAKeyframeAnimation()
+    outImation.keyPath = "opacity"
+    outImation.keyTimes = [0,1]
+    outImation.values = [1,0]
+    outImation.duration = 5
+    outImation.fillMode = kCAFillModeBoth
+    outImation.isRemovedOnCompletion = false
+    // offset fade out at least by duration of fade in
+    outImation.beginTime = CACurrentMediaTime()+4.0
+    layerToFade.add(outImation, forKey: "outOpacity")
+  }
+
+
+  func playNextVideo() {
+    let notificationCenter = NotificationCenter.default
+
+    // remove old entries
+    notificationCenter.removeObserver(self)
+
+    let newPlayer = AVPlayer()
+//    // play another video
+//    let oldPlayer = self.player
+//    self.player = player
+//    self.playerLayer.player = self.player
+//
+//    if self.isPreview {
+//      AerialView.previewPlayer = player
+//    }
+//
+//    debugLog("Setting player for all player layers in \(AerialView.sharedViews)")
+//    for view in AerialView.sharedViews {
+//      view.playerLayer.player = player
+//    }
+//
+//    if oldPlayer == AerialView.previewPlayer {
+//      AerialView.previewView?.playerLayer.player = self.player
+//    }
+
+    let randomVideo = ManifestLoader.instance.randomVideo()
+
+    guard let video = randomVideo else {
+      NSLog("Aerial: Error grabbing random video!")
+      return
+    }
+    let videoURL = video.url
+
+    let asset = CachedOrCachingAsset(videoURL)
+    let dummyAsset = AVAsset(url: videoURL)
+    let fadeTime = CMTimeGetSeconds(dummyAsset.duration) - 10.0
+
+    let item = AVPlayerItem(asset: asset)
+
+    var currentItem: AVPlayerItem?
+
+    //    player.replaceCurrentItem(with: item)
+    if  !currentPlayerIsFrontPlayer {
+      debugLog("\n\n---------\nplaying front player\n")
+      debugLog("\(self.player?.currentItem)")
+      self.player = newPlayer
+      self.playerLayer.player = newPlayer
+      self.player?.replaceCurrentItem(with: item)
+      if self.player?.rate == 0 {
+        self.player?.play()
+      }
+      if self.player?.currentItem !== nil {
+        currentItem = self.player?.currentItem
+      } else {
+        NSLog("Aerial Error: No current item!")
+        return
+      }
+      // fade in front player
+      fadeLayerIn(layerToFade: self.playerLayer)
+
+      self.player?.actionAtItemEnd = AVPlayerActionAtItemEnd.none
+      self.player?.addBoundaryTimeObserver(forTimes: [NSValue(time:kCMTimeZero+CMTimeMakeWithSeconds(fadeTime,1))], queue: DispatchQueue.main) {
+        self.playNextVideo()
+      }
+      self.currentPlayerIsFrontPlayer = true
+
+    } else {
+      debugLog("\n\n---------\nplaying back player\n")
+      self.playerBack = newPlayer
+      self.playerLayerBack.player = newPlayer
+      self.playerBack?.replaceCurrentItem(with: item)
+      if self.playerBack?.rate == 0 {
+        self.playerBack?.play()
+      }
+      // start backplayer, fade it in then fade out front player
+      if self.playerBack?.currentItem !== nil {
+        currentItem = self.playerBack?.currentItem
+      } else {
+        NSLog("Aerial Error: No current item!")
+        return
+      }
+//      fadeLayerIn(layerToFade: self.playerLayerBack)
+      fadeLayerOut(layerToFade: self.playerLayer)
+
+      self.playerBack?.actionAtItemEnd = AVPlayerActionAtItemEnd.none
+      self.playerBack?.addBoundaryTimeObserver(forTimes: [NSValue(time:kCMTimeZero+CMTimeMakeWithSeconds(fadeTime,1))], queue: DispatchQueue.main) {
+        self.playNextVideo()
+      }
+      self.currentPlayerIsFrontPlayer = false;
+
+    }
+
+    debugLog("playing video: \(video.url)")
+
+
+    debugLog("observing current item \(currentItem)")
+    notificationCenter.addObserver(self,
+                                   selector: #selector(AerialView.playerItemDidReachEnd(_:)),
+                                   name: NSNotification.Name.AVPlayerItemDidPlayToEndTime,
+                                   object: currentItem)
+    notificationCenter.addObserver(self,
+                                   selector: #selector(AerialView.playerItemNewErrorLogEntryNotification(_:)),
+                                   name: NSNotification.Name.AVPlayerItemNewErrorLogEntry,
+                                   object: currentItem)
+    notificationCenter.addObserver(self,
+                                   selector: #selector(AerialView.playerItemFailedtoPlayToEnd(_:)),
+                                   name: NSNotification.Name.AVPlayerItemFailedToPlayToEndTime,
+                                   object: currentItem)
+    notificationCenter.addObserver(self,
+                                   selector: #selector(AerialView.playerItemPlaybackStalledNotification(_:)),
+                                   name: NSNotification.Name.AVPlayerItemPlaybackStalled,
+                                   object: currentItem)
+
+
+  }
+
+  // MARK: - Preferences
+
+  override func hasConfigureSheet() -> Bool {
+    return true
+  }
+
+  override func configureSheet() -> NSWindow? {
+    if let controller = preferencesController {
+      return controller.window
+    }
+
+    let controller = PreferencesWindowController(windowNibName: "PreferencesWindow")
+
+    preferencesController = controller
+    return controller.window
+  }
 }


### PR DESCRIPTION
Im using Aerial as a desktop background where the black jump cuts for changing the clip are rather distracting.

So far i have managed to fade in and out for each clip. This could be extended to a smooth crossfade by creating multiple playerlayers.

Unfortunately, i could not get this to work when using the AVAsset from the  CachedOrCachingAsset() method, as the return Asset does not have a valid duration. Maybe someone with more experience has an idea how to get the duration property or how to call the FadeOut event based when the clip is about to end.
