### PR TITLE
[Feature] 4K Video

### DIFF
--- a/Aerial.xcodeproj/project.pbxproj
+++ b/Aerial.xcodeproj/project.pbxproj
@@ -598,6 +598,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_SWIFT_FLAGS = "-D DEBUG";
 				SDKROOT = macosx;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -636,6 +637,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -693,6 +695,7 @@
 				FA7199771D94EC5A00FBC99B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		FACAF19F1BD9FC6000E539DC /* Build configuration list for PBXProject "Aerial" */ = {
 			isa = XCConfigurationList;

--- a/Aerial.xcodeproj/project.pbxproj
+++ b/Aerial.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		AA7E2E5E1FC62E8B00E5F320 /* AerialPlayerItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA7E2E5D1FC62E8B00E5F320 /* AerialPlayerItem.swift */; };
 		FA143CE61BDA3EEF0041A82B /* AVKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FA143CE51BDA3EEF0041A82B /* AVKit.framework */; };
 		FA36BD3F1BE57F8E00D5E03B /* VideoDownload.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA36BD3E1BE57F8E00D5E03B /* VideoDownload.swift */; };
 		FA36BD401BE57F8E00D5E03B /* VideoDownload.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA36BD3E1BE57F8E00D5E03B /* VideoDownload.swift */; };
@@ -57,6 +58,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		AA7E2E5D1FC62E8B00E5F320 /* AerialPlayerItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AerialPlayerItem.swift; sourceTree = "<group>"; };
 		FA143CD61BDA3E880041A82B /* AerialApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AerialApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		FA143CE51BDA3EEF0041A82B /* AVKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVKit.framework; path = System/Library/Frameworks/AVKit.framework; sourceTree = SDKROOT; };
 		FA36BD3E1BE57F8E00D5E03B /* VideoDownload.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = VideoDownload.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
@@ -218,6 +220,7 @@
 			children = (
 				FAC36F431BE1756D007F2A20 /* AerialView.swift */,
 				FAC36F441BE1756D007F2A20 /* CheckCellView.swift */,
+				AA7E2E5D1FC62E8B00E5F320 /* AerialPlayerItem.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -454,6 +457,7 @@
 				FAC36F571BE1756D007F2A20 /* PreferencesWindowController.swift in Sources */,
 				FAC36F671BE1778C007F2A20 /* ManifestLoader.swift in Sources */,
 				FAC36F591BE1756D007F2A20 /* AerialVideo.swift in Sources */,
+				AA7E2E5E1FC62E8B00E5F320 /* AerialPlayerItem.swift in Sources */,
 				FAF450211BE2B45D00C1F98A /* VideoLoader.swift in Sources */,
 				FAC36F6A1BE1780B007F2A20 /* Debug.swift in Sources */,
 				FAB22A7E1BE17D7D0065C0F5 /* AssetLoaderDelegate.swift in Sources */,

--- a/Aerial/Resources/PreferencesWindow.xib
+++ b/Aerial/Resources/PreferencesWindow.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="13529" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="12121" systemVersion="17B48" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.AVKitIBPlugin" version="13529"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13529"/>
+        <plugIn identifier="com.apple.AVKitIBPlugin" version="12121"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="12121"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -42,11 +42,11 @@
                                 <tabViewItems>
                                     <tabViewItem label="Main" identifier="1" id="dfl-QA-fvD">
                                         <view key="view" ambiguous="YES" id="zsM-Ha-kCO">
-                                            <rect key="frame" x="10" y="33" width="127" height="0.0"/>
+                                            <rect key="frame" x="10" y="33" width="607" height="286"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <scrollView fixedFrame="YES" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jNc-EK-7cY">
-                                                    <rect key="frame" x="4" y="-254" width="150" height="254"/>
+                                                    <rect key="frame" x="4" y="32" width="150" height="254"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                     <clipView key="contentView" ambiguous="YES" drawsBackground="NO" id="4QR-cO-33N">
                                                         <rect key="frame" x="1" y="1" width="148" height="252"/>
@@ -76,7 +76,7 @@
                                                                                 <rect key="frame" x="1" y="1" width="145" height="17"/>
                                                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                                 <subviews>
-                                                                                    <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="LAq-iM-gNn">
+                                                                                    <textField verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LAq-iM-gNn">
                                                                                         <rect key="frame" x="0.0" y="1" width="145" height="14"/>
                                                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                         <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="HEADER CELL" id="0xW-C7-M1h">
@@ -94,14 +94,12 @@
                                                                                 <rect key="frame" x="1" y="20" width="145" height="17"/>
                                                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                                 <subviews>
-                                                                                    <imageView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="lTj-ap-BmD">
-                                                                                        <rect key="frame" x="3" y="0.0" width="17" height="17"/>
-                                                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                    <imageView translatesAutoresizingMaskIntoConstraints="NO" id="lTj-ap-BmD">
+                                                                                        <rect key="frame" x="3" y="2" width="14" height="14"/>
                                                                                         <imageCell key="cell" refusesFirstResponder="YES" imageScaling="proportionallyDown" image="NSActionTemplate" id="F9h-eS-gdN"/>
                                                                                     </imageView>
-                                                                                    <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vTe-Ig-6rK">
-                                                                                        <rect key="frame" x="25" y="0.0" width="120" height="17"/>
-                                                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                    <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vTe-Ig-6rK">
+                                                                                        <rect key="frame" x="20" y="0.0" width="96" height="17"/>
                                                                                         <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="YEO-B3-Myh">
                                                                                             <font key="font" metaFont="system"/>
                                                                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -109,6 +107,12 @@
                                                                                         </textFieldCell>
                                                                                     </textField>
                                                                                 </subviews>
+                                                                                <constraints>
+                                                                                    <constraint firstItem="vTe-Ig-6rK" firstAttribute="leading" secondItem="lTj-ap-BmD" secondAttribute="trailing" constant="5" id="Tpt-QL-gha"/>
+                                                                                    <constraint firstItem="vTe-Ig-6rK" firstAttribute="centerY" secondItem="hIe-18-Evw" secondAttribute="centerY" id="Veh-bS-Y5o"/>
+                                                                                    <constraint firstItem="lTj-ap-BmD" firstAttribute="centerY" secondItem="hIe-18-Evw" secondAttribute="centerY" id="o1o-S9-lvL"/>
+                                                                                    <constraint firstItem="lTj-ap-BmD" firstAttribute="leading" secondItem="hIe-18-Evw" secondAttribute="leading" constant="3" id="wnL-Jg-J7a"/>
+                                                                                </constraints>
                                                                                 <connections>
                                                                                     <outlet property="imageView" destination="lTj-ap-BmD" id="bTf-Wh-AIw"/>
                                                                                     <outlet property="textField" destination="vTe-Ig-6rK" id="G7i-QQ-xur"/>
@@ -118,17 +122,15 @@
                                                                                 <rect key="frame" x="1" y="39" width="145" height="17"/>
                                                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                                 <subviews>
-                                                                                    <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4gS-Ev-A8c">
-                                                                                        <rect key="frame" x="3" y="0.0" width="120" height="18"/>
-                                                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                    <button translatesAutoresizingMaskIntoConstraints="NO" id="4gS-Ev-A8c">
+                                                                                        <rect key="frame" x="3" y="0.0" width="22" height="18"/>
                                                                                         <buttonCell key="cell" type="check" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="9L7-4L-A4w">
                                                                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                                                             <font key="font" metaFont="system"/>
                                                                                         </buttonCell>
                                                                                     </button>
-                                                                                    <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5qU-xC-8TY">
-                                                                                        <rect key="frame" x="25" y="0.0" width="120" height="17"/>
-                                                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                    <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5qU-xC-8TY">
+                                                                                        <rect key="frame" x="26" y="0.0" width="96" height="17"/>
                                                                                         <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="hxB-gg-rAu">
                                                                                             <font key="font" metaFont="system"/>
                                                                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -136,6 +138,12 @@
                                                                                         </textFieldCell>
                                                                                     </textField>
                                                                                 </subviews>
+                                                                                <constraints>
+                                                                                    <constraint firstItem="4gS-Ev-A8c" firstAttribute="centerY" secondItem="X6H-3G-WWn" secondAttribute="centerY" id="2tA-aE-2Ze"/>
+                                                                                    <constraint firstItem="5qU-xC-8TY" firstAttribute="centerY" secondItem="X6H-3G-WWn" secondAttribute="centerY" id="IRp-rt-GvU"/>
+                                                                                    <constraint firstItem="4gS-Ev-A8c" firstAttribute="leading" secondItem="X6H-3G-WWn" secondAttribute="leading" constant="5" id="NLM-cu-HyK"/>
+                                                                                    <constraint firstItem="5qU-xC-8TY" firstAttribute="leading" secondItem="4gS-Ev-A8c" secondAttribute="trailing" constant="5" id="OTg-V2-5wq"/>
+                                                                                </constraints>
                                                                                 <connections>
                                                                                     <outlet property="checkButton" destination="4gS-Ev-A8c" id="oXZ-Tj-jgf"/>
                                                                                     <outlet property="textField" destination="5qU-xC-8TY" id="Jbw-CN-faK"/>
@@ -162,11 +170,11 @@
                                                     </scroller>
                                                 </scrollView>
                                                 <avPlayerView fixedFrame="YES" controlsStyle="inline" translatesAutoresizingMaskIntoConstraints="NO" id="Rc1-hl-hSC">
-                                                    <rect key="frame" x="207" y="-186" width="336" height="188"/>
+                                                    <rect key="frame" x="207" y="100" width="336" height="188"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                 </avPlayerView>
                                                 <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hOD-gE-gxl">
-                                                    <rect key="frame" x="467" y="-265" width="132" height="32"/>
+                                                    <rect key="frame" x="467" y="21" width="132" height="32"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                     <buttonCell key="cell" type="bevel" title="Visit Project Page" bezelStyle="rounded" alignment="center" inset="2" id="5mJ-Tt-2db">
                                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -177,7 +185,7 @@
                                                     </connections>
                                                 </button>
                                                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9Xe-S2-eQT">
-                                                    <rect key="frame" x="205" y="-215" width="244" height="18"/>
+                                                    <rect key="frame" x="205" y="71" width="244" height="18"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                     <buttonCell key="cell" type="check" title="Play Different Aerial On Each Display" bezelStyle="regularSquare" imagePosition="left" inset="2" id="Mp6-m9-C2d">
                                                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -188,7 +196,7 @@
                                                     </connections>
                                                 </button>
                                                 <button horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="XSQ-4P-bI2">
-                                                    <rect key="frame" x="4" y="-289" width="44" height="33"/>
+                                                    <rect key="frame" x="4" y="-3" width="44" height="33"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                     <buttonCell key="cell" type="bevel" bezelStyle="rounded" image="NSActionTemplate" imagePosition="only" alignment="center" state="on" inset="2" id="4Dx-Hp-CRf">
                                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -259,7 +267,7 @@
                                                         <action selector="cacheAllNow:" target="-2" id="poN-ta-Wfd"/>
                                                     </connections>
                                                 </button>
-                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Z45-8U-mbl">
+                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Z45-8U-mbl">
                                                     <rect key="frame" x="175" y="87" width="437" height="17"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Idle" id="QNE-T2-Dpe">
@@ -268,7 +276,7 @@
                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                     </textFieldCell>
                                                 </textField>
-                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ELj-7t-LmS">
+                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ELj-7t-LmS">
                                                     <rect key="frame" x="29" y="43" width="134" height="17"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Total Progress" id="7yK-FT-4Kh">
@@ -281,7 +289,7 @@
                                                     <rect key="frame" x="214" y="16" width="130" height="20"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                 </progressIndicator>
-                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="u6T-MT-X4f">
+                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="u6T-MT-X4f">
                                                     <rect key="frame" x="212" y="43" width="134" height="17"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Current Video" id="eyb-qY-C1D">

--- a/Aerial/Resources/PreferencesWindow.xib
+++ b/Aerial/Resources/PreferencesWindow.xib
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11201" systemVersion="16A323" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="13529" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.AVKitIBPlugin" version="11201"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11201"/>
+        <plugIn identifier="com.apple.AVKitIBPlugin" version="13529"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13529"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="PreferencesWindowController">
@@ -41,11 +42,11 @@
                                 <tabViewItems>
                                     <tabViewItem label="Main" identifier="1" id="dfl-QA-fvD">
                                         <view key="view" id="zsM-Ha-kCO">
-                                            <rect key="frame" x="10" y="33" width="607" height="286"/>
+                                            <rect key="frame" x="10" y="33" width="127" height="0.0"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <scrollView fixedFrame="YES" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jNc-EK-7cY">
-                                                    <rect key="frame" x="4" y="32" width="150" height="254"/>
+                                                    <rect key="frame" x="4" y="-254" width="150" height="254"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                     <clipView key="contentView" ambiguous="YES" drawsBackground="NO" id="4QR-cO-33N">
                                                         <rect key="frame" x="1" y="1" width="148" height="252"/>
@@ -58,7 +59,7 @@
                                                                 <color key="backgroundColor" name="_sourceListBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                                 <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                                                 <tableColumns>
-                                                                    <tableColumn width="145" minWidth="16" maxWidth="1000" id="Grd-eN-eTf">
+                                                                    <tableColumn identifier="" width="145" minWidth="16" maxWidth="1000" id="Grd-eN-eTf">
                                                                         <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border">
                                                                             <font key="font" metaFont="smallSystem"/>
                                                                             <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
@@ -152,20 +153,20 @@
                                                         <nil key="backgroundColor"/>
                                                     </clipView>
                                                     <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="Ano-CK-gsw">
-                                                        <rect key="frame" x="1" y="-15" width="0.0" height="16"/>
+                                                        <rect key="frame" x="-7" y="-14" width="0.0" height="15"/>
                                                         <autoresizingMask key="autoresizingMask"/>
                                                     </scroller>
                                                     <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="sIg-0t-YWZ">
-                                                        <rect key="frame" x="-15" y="1" width="16" height="0.0"/>
+                                                        <rect key="frame" x="-14" y="-7" width="15" height="0.0"/>
                                                         <autoresizingMask key="autoresizingMask"/>
                                                     </scroller>
                                                 </scrollView>
                                                 <avPlayerView fixedFrame="YES" controlsStyle="inline" translatesAutoresizingMaskIntoConstraints="NO" id="Rc1-hl-hSC">
-                                                    <rect key="frame" x="207" y="100" width="336" height="188"/>
+                                                    <rect key="frame" x="207" y="-186" width="336" height="188"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                 </avPlayerView>
                                                 <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hOD-gE-gxl">
-                                                    <rect key="frame" x="467" y="21" width="132" height="32"/>
+                                                    <rect key="frame" x="467" y="-265" width="132" height="32"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                     <buttonCell key="cell" type="bevel" title="Visit Project Page" bezelStyle="rounded" alignment="center" inset="2" id="5mJ-Tt-2db">
                                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -176,7 +177,7 @@
                                                     </connections>
                                                 </button>
                                                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9Xe-S2-eQT">
-                                                    <rect key="frame" x="205" y="71" width="244" height="18"/>
+                                                    <rect key="frame" x="205" y="-215" width="244" height="18"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                     <buttonCell key="cell" type="check" title="Play Different Aerial On Each Display" bezelStyle="regularSquare" imagePosition="left" inset="2" id="Mp6-m9-C2d">
                                                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -187,7 +188,7 @@
                                                     </connections>
                                                 </button>
                                                 <button horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="XSQ-4P-bI2">
-                                                    <rect key="frame" x="4" y="-3" width="44" height="33"/>
+                                                    <rect key="frame" x="4" y="-289" width="44" height="33"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                     <buttonCell key="cell" type="bevel" bezelStyle="rounded" image="NSActionTemplate" imagePosition="only" alignment="center" state="on" inset="2" id="4Dx-Hp-CRf">
                                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>

--- a/Aerial/Resources/PreferencesWindow.xib
+++ b/Aerial/Resources/PreferencesWindow.xib
@@ -26,7 +26,7 @@
         <window identifier="preferencesWindow" title="Preferences" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" animationBehavior="default" id="QvC-M9-y7g">
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="0.0" y="0.0" width="625" height="365"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1418"/>
             <view key="contentView" identifier="windowView" id="EiT-Mj-1SZ">
                 <rect key="frame" x="0.0" y="0.0" width="625" height="365"/>
                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -41,7 +41,7 @@
                                 <font key="font" metaFont="system"/>
                                 <tabViewItems>
                                     <tabViewItem label="Main" identifier="1" id="dfl-QA-fvD">
-                                        <view key="view" id="zsM-Ha-kCO">
+                                        <view key="view" ambiguous="YES" id="zsM-Ha-kCO">
                                             <rect key="frame" x="10" y="33" width="127" height="0.0"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
@@ -202,7 +202,7 @@
                                         </view>
                                     </tabViewItem>
                                     <tabViewItem label="Cache" identifier="2" id="kp1-xv-zNG">
-                                        <view key="view" ambiguous="YES" id="93q-v8-yxM">
+                                        <view key="view" id="93q-v8-yxM">
                                             <rect key="frame" x="10" y="33" width="607" height="286"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>

--- a/Aerial/Source/Controllers/PreferencesWindowController.swift
+++ b/Aerial/Source/Controllers/PreferencesWindowController.swift
@@ -495,23 +495,23 @@ NSOutlineViewDelegate, VideoDownloadDelegate {
             return video.isAvailableOffline == false
         }
         
-        if uncached.count == 0 {
-            cacheStatusLabel.stringValue = "All videos have been cached"
-            return
-        }
-        
         NSLog("uncached: \(uncached)")
         
         totalProgress.maxValue = Double(manifestVideos.count)
         totalProgress.doubleValue = Double(manifestVideos.count) - Double(uncached.count)
         NSLog("total process max value: \(totalProgress.maxValue), current value: \(totalProgress.doubleValue)")
         
+        if uncached.count == 0 {
+            cacheStatusLabel.stringValue = "All videos have been cached"
+            return
+        }
+        
         let video = uncached[0]
         
         // find video that hasn't been cached
         let videoDownload = VideoDownload(video: video, delegate: self)
         
-        cacheStatusLabel.stringValue = "Caching video \(video.name) \(video.timeOfDay.capitalized): \(video.id)"
+        cacheStatusLabel.stringValue = "Caching video \(video.name) \(video.timeOfDay.capitalized): \(video.url)"
         
         currentVideoDownload = videoDownload
         videoDownload.startDownload()

--- a/Aerial/Source/Controllers/PreferencesWindowController.swift
+++ b/Aerial/Source/Controllers/PreferencesWindowController.swift
@@ -451,18 +451,18 @@ NSOutlineViewDelegate, VideoDownloadDelegate {
         }
     }
     
-    func outlineView(_ outlineView: NSOutlineView, heightOfRowByItem item: Any) -> CGFloat {
-        switch item {
-        case is AerialVideo:
-            return 18
-        case is TimeOfDay:
-            return 18
-        case is City:
-            return 18
-        default:
-            return 0
-        }
-    }
+//    func outlineView(_ outlineView: NSOutlineView, heightOfRowByItem item: Any) -> CGFloat {
+//        switch item {
+//        case is AerialVideo:
+//            return 18
+//        case is TimeOfDay:
+//            return outlineView.textFi
+//        case is City:
+//            return 18
+//        default:
+//            fatalError("unhandled item in heightOfRowByItem for \(item)")
+//        }
+//    }
     
     // MARK: - Caching
     

--- a/Aerial/Source/Models/AerialVideo.swift
+++ b/Aerial/Source/Models/AerialVideo.swift
@@ -8,7 +8,11 @@
 
 import Foundation
 
-class AerialVideo: CustomStringConvertible {
+class AerialVideo: CustomStringConvertible, Equatable {
+    static func ==(lhs: AerialVideo, rhs: AerialVideo) -> Bool {
+        return lhs.id == rhs.id && lhs.url == rhs.url
+    }
+    
     let id: String
     let name: String
     let type: String

--- a/Aerial/Source/Models/AerialVideo.swift
+++ b/Aerial/Source/Models/AerialVideo.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-class AerialVideo {
+class AerialVideo: CustomStringConvertible {
     let id: String
     let name: String
     let type: String
@@ -31,5 +31,9 @@ class AerialVideo {
         self.type = type
         self.timeOfDay = timeOfDay
         self.url = URL(string: url)!
+    }
+    
+    var description: String {
+        return "id=\(id), name=\(name), type=\(type), timeofDay=\(timeOfDay), url=\(url)"
     }
 }

--- a/Aerial/Source/Models/Cache/VideoLoader.swift
+++ b/Aerial/Source/Models/Cache/VideoLoader.swift
@@ -111,7 +111,7 @@ class VideoLoader: NSObject, NSURLConnectionDataDelegate {
             // check if we've already been sending content, or we're at right byte offset
             if loadedLocation >= requestedRange.location {
                 
-                let requestedEndOffset = Int(dataRequest.requestedOffset + dataRequest.requestedLength)
+                let requestedEndOffset = Int(dataRequest.requestedOffset + Int64(dataRequest.requestedLength))
                 
                 let pendingDataEndOffset = loadedLocation + data.count
                 
@@ -140,7 +140,7 @@ class VideoLoader: NSObject, NSURLConnectionDataDelegate {
                     let responseData = data.subdata(in: inset..<end)
                     dataRequest.respond(with: responseData)
                     
-                    if dataRequest.currentOffset >= dataRequest.requestedOffset + dataRequest.requestedLength {
+                    if dataRequest.currentOffset >= dataRequest.requestedOffset + Int64(dataRequest.requestedLength) {
                         self.loadingRequest.finishLoading()
                         self.connection?.cancel()
                     }

--- a/Aerial/Source/Models/Extensions/CollectionType+Shuffling.swift
+++ b/Aerial/Source/Models/Extensions/CollectionType+Shuffling.swift
@@ -7,17 +7,16 @@ import Foundation
 
 // shuffling thanks to Nate Cook http://stackoverflow.com/questions/24026510/how-do-i-shuffle-an-array-in-swift
 
-extension MutableCollection where Indices.Iterator.Element == Index {
-    /// Shuffles the contents of this collection.
+extension MutableCollection {
+    /// Shuffle the elements of `self` in-place.
     mutating func shuffle() {
-        let c = count
-        guard c > 1 else { return }
+        // empty and single-element collections don't shuffle
+        if count < 2 { return }
         
-        for (unshuffledCount, firstUnshuffled) in zip(stride(from: c, to: 1, by: -1), indices) {
-            let d: IndexDistance = numericCast(arc4random_uniform(numericCast(unshuffledCount)))
-            guard d != 0 else { continue }
-            let i = index(firstUnshuffled, offsetBy: d)
-            swap(&self[firstUnshuffled], &self[i])
+        for i in indices.dropLast() {
+            let diff = distance(from: i, to: endIndex)
+            let j = index(i, offsetBy: numericCast(arc4random_uniform(numericCast(diff))))
+            swapAt(i, j)
         }
     }
 }

--- a/Aerial/Source/Models/Extensions/CollectionType+Shuffling.swift
+++ b/Aerial/Source/Models/Extensions/CollectionType+Shuffling.swift
@@ -1,22 +1,22 @@
+
 //
 //  CollectionType+Shuffling.swift
 //  Aerial
 //
-
 import Foundation
 
 // shuffling thanks to Nate Cook http://stackoverflow.com/questions/24026510/how-do-i-shuffle-an-array-in-swift
-
-extension MutableCollection {
-    /// Shuffle the elements of `self` in-place.
+extension MutableCollection where Indices.Iterator.Element == Index {
+    /// Shuffles the contents of this collection.
     mutating func shuffle() {
-        // empty and single-element collections don't shuffle
-        if count < 2 { return }
+        let c = count
+        guard c > 1 else { return }
         
-        for i in indices.dropLast() {
-            let diff = distance(from: i, to: endIndex)
-            let j = index(i, offsetBy: numericCast(arc4random_uniform(numericCast(diff))))
-            swapAt(i, j)
+        for (unshuffledCount, firstUnshuffled) in zip(stride(from: c, to: 1, by: -1), indices) {
+            let d: IndexDistance = numericCast(arc4random_uniform(numericCast(unshuffledCount)))
+            guard d != 0 else { continue }
+            let i = index(firstUnshuffled, offsetBy: d)
+            swap(&self[firstUnshuffled], &self[i])
         }
     }
 }

--- a/Aerial/Source/Models/ManifestLoader.swift
+++ b/Aerial/Source/Models/ManifestLoader.swift
@@ -73,7 +73,7 @@ class ManifestLoader {
             })
             
         }
-        let apiURL = "http://a1.phobos.apple.com/us/r1000/000/Features/atv/AutumnResources/videos/entries.json"
+        let apiURL = "https://sylvan.apple.com/Aerials/2x/entries.json"
         guard let url = URL(string: apiURL) else {
             fatalError("Couldn't init URL from string")
         }
@@ -100,8 +100,8 @@ class ManifestLoader {
         do {
             let options = JSONSerialization.ReadingOptions.allowFragments
             let batches = try JSONSerialization.jsonObject(with: data,
-                                                           options: options) as! Array<NSDictionary>
-            
+                                                           options: options)
+            if let batches = batches as? Array<NSDictionary> {
             for batch: NSDictionary in batches {
                 let assets = batch["assets"] as! Array<NSDictionary>
                 
@@ -115,6 +115,28 @@ class ManifestLoader {
                     if type != "video" {
                         continue
                     }
+                    
+                    let video = AerialVideo(id: id,
+                                            name: name,
+                                            type: type,
+                                            timeOfDay: timeOfDay,
+                                            url: url)
+                    
+                    videos.append(video)
+                    
+                    checkContentLength(video)
+                }
+            }
+            }
+            else if let batch = batches as? NSDictionary {
+                let assets = batch["assets"] as! Array<NSDictionary>
+                
+                for item in assets {
+                    let url = item["url-4K-SDR"] as! String
+                    let name = item["accessibilityLabel"] as! String
+                    let timeOfDay = "day"
+                    let id = item["id"] as! String
+                    let type = "video"
                     
                     let video = AerialVideo(id: id,
                                             name: name,

--- a/Aerial/Source/Models/ManifestLoader.swift
+++ b/Aerial/Source/Models/ManifestLoader.swift
@@ -101,53 +101,30 @@ class ManifestLoader {
             let options = JSONSerialization.ReadingOptions.allowFragments
             let batches = try JSONSerialization.jsonObject(with: data,
                                                            options: options)
-            if let batches = batches as? Array<NSDictionary> {
-            for batch: NSDictionary in batches {
-                let assets = batch["assets"] as! Array<NSDictionary>
-                
-                for item in assets {
-                    let url = item["url"] as! String
-                    let name = item["accessibilityLabel"] as! String
-                    let timeOfDay = item["timeOfDay"] as! String
-                    let id = item["id"] as! String
-                    let type = item["type"] as! String
-                    
-                    if type != "video" {
-                        continue
-                    }
-                    
-                    let video = AerialVideo(id: id,
-                                            name: name,
-                                            type: type,
-                                            timeOfDay: timeOfDay,
-                                            url: url)
-                    
-                    videos.append(video)
-                    
-                    checkContentLength(video)
-                }
+            
+            guard let batch = batches as? NSDictionary else {
+                NSLog("Aerial: Encountered unexpected content type for batch")
+                return
             }
-            }
-            else if let batch = batches as? NSDictionary {
-                let assets = batch["assets"] as! Array<NSDictionary>
+            
+            let assets = batch["assets"] as! Array<NSDictionary>
+            
+            for item in assets {
+                let url = item["url-4K-SDR"] as! String
+                let name = item["accessibilityLabel"] as! String
+                let timeOfDay = "day"
+                let id = item["id"] as! String
+                let type = "video"
                 
-                for item in assets {
-                    let url = item["url-4K-SDR"] as! String
-                    let name = item["accessibilityLabel"] as! String
-                    let timeOfDay = "day"
-                    let id = item["id"] as! String
-                    let type = "video"
-                    
-                    let video = AerialVideo(id: id,
-                                            name: name,
-                                            type: type,
-                                            timeOfDay: timeOfDay,
-                                            url: url)
-                    
-                    videos.append(video)
-                    
-                    checkContentLength(video)
-                }
+                let video = AerialVideo(id: id,
+                                        name: name,
+                                        type: type,
+                                        timeOfDay: timeOfDay,
+                                        url: url)
+                
+                videos.append(video)
+                
+                checkContentLength(video)
             }
             
             self.loadedManifest = videos

--- a/Aerial/Source/Models/ManifestLoader.swift
+++ b/Aerial/Source/Models/ManifestLoader.swift
@@ -28,13 +28,18 @@ class ManifestLoader {
         }
     }
     
-    func randomVideo() -> AerialVideo? {
+    func randomVideo(excluding: [AerialVideo]) -> AerialVideo? {
         let shuffled = loadedManifest.shuffled()
         for video in shuffled {
             let inRotation = preferences.videoIsInRotation(videoID: video.id)
             
             if !inRotation {
                 debugLog("video is disabled: \(video)")
+                continue
+            }
+            
+            if excluding.contains(video) {
+                debugLog("video is excluded because it's already in use: \(video)")
                 continue
             }
             

--- a/Aerial/Source/Views/AerialPlayerItem.swift
+++ b/Aerial/Source/Views/AerialPlayerItem.swift
@@ -1,0 +1,20 @@
+//
+//  AerialPlayerItem.swift
+//  Aerial
+//
+//  Created by Ethan Setnik on 11/22/17.
+//  Copyright © 2017 John Coates. All rights reserved.
+//
+import AVFoundation
+import AVKit
+
+class AerialPlayerItem: AVPlayerItem {
+    var video: AerialVideo?
+    
+    init(video: AerialVideo) {
+        let videoURL = video.url
+        let asset = CachedOrCachingAsset(videoURL)
+        super.init(asset: asset, automaticallyLoadedAssetKeys: nil)
+        self.video = video
+    }
+}

--- a/Aerial/Source/Views/AerialView.swift
+++ b/Aerial/Source/Views/AerialView.swift
@@ -194,8 +194,6 @@ class AerialView: ScreenSaverView {
         debugLog("playing next video for player \(String(describing: player))")
     }
     
-    // MARK: - Playing Videos
-    
     func playNextVideo() {
         let notificationCenter = NotificationCenter.default
         
@@ -221,18 +219,22 @@ class AerialView: ScreenSaverView {
             AerialView.previewView?.playerLayer.player = self.player
         }
         
-        let randomVideo = ManifestLoader.instance.randomVideo()
+        // get a list of current videos that should be excluded from the candidate selection
+        // for the next video. This prevents the same video from being shown twice in a row
+        // as well as the same video being shown on two different monitors even when sharingPlayers
+        // is false
+        let currentVideos: [AerialVideo] = AerialView.players.flatMap { (player) -> AerialVideo? in
+            (player.currentItem as? AerialPlayerItem)?.video
+        }
+        
+        let randomVideo = ManifestLoader.instance.randomVideo(excluding: currentVideos)
         
         guard let video = randomVideo else {
             NSLog("Aerial: Error grabbing random video!")
             return
         }
-        let videoURL = video.url
         
-        let asset = CachedOrCachingAsset(videoURL)
-//        let asset = AVAsset(URL: videoURL)
-        
-        let item = AVPlayerItem(asset: asset)
+        let item = AerialPlayerItem(video: video)
         
         player.replaceCurrentItem(with: item)
         

--- a/Aerial/Source/Views/AerialView.swift
+++ b/Aerial/Source/Views/AerialView.swift
@@ -191,7 +191,7 @@ class AerialView: ScreenSaverView {
         debugLog("notification: \(aNotification)")
         playNextVideo()
 
-        debugLog("playing next video for player \(player)")
+        debugLog("playing next video for player \(String(describing: player))")
     }
     
     // MARK: - Playing Videos


### PR DESCRIPTION
Todo:
- [x] Replaces existing resources with 4K SDR assets
- [ ] Consider allowing user to select both 4K and HD assets
- [x] Fix issue where cached download count is off by 1 (JohnCoates/Aerial/issues/350)
- [x] Fix issue where video would be reused across multiple monitors even after enabling `Play Different Aerial On Each Display`. It is caused because the random video selection does not consider videos already in use. (JohnCoates/Aerial/issues/212)
- [x] Fix issue where titles are cut off (JohnCoates/Aerial/issues/413)