### PR TITLE
Fix displayed cache location when location cannot be found

### DIFF
--- a/Aerial/Resources/PreferencesWindow.xib
+++ b/Aerial/Resources/PreferencesWindow.xib
@@ -219,9 +219,8 @@
                                                 <pathControl verticalHuggingPriority="750" fixedFrame="YES" allowsExpansionToolTips="YES" translatesAutoresizingMaskIntoConstraints="NO" id="XAJ-Se-rwG">
                                                     <rect key="frame" x="10" y="200" width="587" height="22"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                    <pathCell key="cell" selectable="YES" editable="YES" alignment="left" id="gVD-I9-Ldu">
+                                                    <pathCell key="cell" selectable="YES" editable="YES" alignment="left" placeholderString="Failed to load cache location" id="gVD-I9-Ldu">
                                                         <font key="font" metaFont="system"/>
-                                                        <url key="url" string="file://localhost/Applications/"/>
                                                         <color key="backgroundColor" red="0.89803921568627454" green="0.92549019607843142" blue="0.97254901960784312" alpha="1" colorSpace="deviceRGB"/>
                                                     </pathCell>
                                                 </pathControl>

--- a/Aerial/Source/Controllers/PreferencesWindowController.swift
+++ b/Aerial/Source/Controllers/PreferencesWindowController.swift
@@ -102,7 +102,9 @@ NSOutlineViewDelegate, VideoDownloadDelegate {
         
         if let cacheDirectory = VideoCache.cacheDirectory {
             cacheLocation.url = URL(fileURLWithPath: cacheDirectory as String)
-        }
+		} else {
+			cacheLocation.url = nil
+		}
         
         cacheStatusLabel.isEditable = false
     }


### PR DESCRIPTION
When the cache location cant be found (for example, when it is on an external drive), it is displayed that the cache location is in Applications, which is extremely confusing for the user.

![screen shot 2018-04-21 at 11 53 47 pm](https://user-images.githubusercontent.com/20720262/39084899-5edba400-45bf-11e8-9f24-bc7d1d35f020.png)

This fix adds placeholder text stating that the cache location could not be found and removes the default "Applications" location.