### PR TITLE
Don't redownload the tar file if already available locally

### DIFF
--- a/Aerial/App/Resources/Info.plist
+++ b/Aerial/App/Resources/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4b8</string>
+	<string>1.4b10</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Aerial/Resources/Info.plist
+++ b/Aerial/Resources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4b8</string>
+	<string>1.4b10</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Aerial/Source/Models/ManifestLoader.swift
+++ b/Aerial/Source/Models/ManifestLoader.swift
@@ -115,17 +115,27 @@ class ManifestLoader {
                 }
             }
         }
+        
+        if let cacheDirectory = VideoCache.cacheDirectory {
+            var cacheResourcesString = cacheDirectory
+            cacheResourcesString.append(contentsOf: "/resources.tar")
 
-        // updated url for tvOS12, json is now in a tar file
-        let apiURL = "https://sylvan.apple.com/Aerials/resources.tar"
-        guard let url = URL(string: apiURL) else {
-            fatalError("Couldn't init URL from string")
+            let fileManager = FileManager.default
+            if fileManager.fileExists(atPath: cacheResourcesString) {
+                loadSavedManifest()
+            } else {
+                // updated url for tvOS12, json is now in a tar file
+                let apiURL = "https://sylvan.apple.com/Aerials/resources.tar"
+                guard let url = URL(string: apiURL) else {
+                    fatalError("Couldn't init URL from string")
+                }
+                // use ephemeral session so when we load json offline it fails and puts us in offline mode
+                let configuration = URLSessionConfiguration.ephemeral
+                let session = URLSession(configuration: configuration)
+                let task = session.dataTask(with: url, completionHandler: completionHandler)
+                task.resume()
+            }
         }
-        // use ephemeral session so when we load json offline it fails and puts us in offline mode
-        let configuration = URLSessionConfiguration.ephemeral
-        let session = URLSession(configuration: configuration)
-        let task = session.dataTask(with: url, completionHandler: completionHandler)
-        task.resume()
     }
     
     func loadSavedManifest() {


### PR DESCRIPTION
This is a small patch following discussion with @esetnik at https://github.com/JohnCoates/Aerial/issues/509

This patch will stop Aerial from redownloading the ressources.tar file from Apple's server if it's already available locally. 