### PR TITLE
generalized Manual Installation instructions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -27,14 +27,17 @@ You can see a list of contributors [here](https://github.com/JohnCoates/Aerial/g
 ### Manual Installation
 *Rather install from Terminal or have auto-updates? Look at the Brew Cask section below!*
 
-1. **Close System Preferences**
-2. [Click here to Download](https://github.com/JohnCoates/Aerial/releases/download/v1.4.5/Aerial.saver.zip) (Version 1.4.5, November 3, 2018, see [changes here](https://github.com/JohnCoates/Aerial/releases/tag/v1.4.5)). (**If you are a new user**, Apple has just added some new videos and made some changes that can confuse Aerial 1.4.5. Because of this, you may see duplicates in the user interface with version 1.4.5. We suggest you give [1.4.6beta5 a try instead](https://github.com/JohnCoates/Aerial/releases/download/v1.4.6beta5/Aerial.saver.zip) (November 21, 2018), this version will properly handle the duplicate issue. You can find more information on changes on [this issue](https://github.com/JohnCoates/Aerial/issues/630).)
+1. Quit **System Preferences**.
+2. [Download the latest release of Aerial.saver.zip](https://github.com/JohnCoates/Aerial/releases/latest).
+
+    **If you are a new user**, Apple has just added some new videos and made some changes that can confuse the current build of Aerial. Because of this, you may see duplicates in the user interface. We suggest you [give the current beta (1.4.6beta5+) a try instead](https://github.com/JohnCoates/Aerial/releases), as this version will properly handle the duplicate issue (you can find more information on changes on [this issue](https://github.com/JohnCoates/Aerial/issues/630)).
+
 3. Unzip the downloaded file (if you use Safari, it should already be done for you).
-4. Open **Aerial.saver** (double click), it will open System Preferences and ask you if you want to install for all users or for your user only. 
+4. Double-click **Aerial.saver**; it will open in **System Preferences > Desktop & Screen Saver** and ask you if you want to install for all users or for your user only.
 
-If you see an error message saying "This app is damaged and can't be opened, you should move it to the trash", we suggest that **you download the file with Safari**, to prevent macOS Gatekeeper from throwing that error. Note that some outdated unzip software may cause that issue too. 
+    If you see an error message saying "This app is damaged and can't be opened, you should move it to the trash", we suggest that **you download the file with Safari**, to prevent macOS Gatekeeper from throwing that error. Note that some outdated unzip software may cause that issue too.
 
-**Important**: If you haven't closed System Preferences before installation and were upgrading from a previous version, we strongly recommend you close System Preferences after the installation and reopen it, as Swift screensavers aren't loaded correctly otherwise when updated. 
+    **Important**: If you haven't quit System Preferences before installation and were upgrading from a previous version, we strongly recommend you quit the application after installation, then reopen it, as updated Swift screensavers aren't loaded correctly in an active System Preferences session.
 
 ### Brew Cask Support - (Updated for 1.4.5)
 


### PR DESCRIPTION
- generalized Manual Installation instructions to not call out specific latest stable/beta releases (as this could potentially lessen the amount of editing you need to do every time a new version of Aerial is released)
- indented step-specific note paragraphs in Manual Installation to group with the associated numbered step