### PR TITLE
Updated community POI, grammar

### DIFF
--- a/Resources/Community/en.json
+++ b/Resources/Community/en.json
@@ -316,8 +316,8 @@
             "name" : "Embarcadero, Market Street",
             "pointsOfInterest" : {
                 "0" : "Heading southwest over San Francisco Bay to the San Francisco Ferry Building",
-                "110" : "Approaching the Port of San Francisco Ferry Building and the Embarcadero",
-                "160" : "Heading southwest along Market Street in downtown San Francisco"
+                "150" : "Approaching the Port of San Francisco Ferry Building and the Embarcadero",
+                "210" : "Heading southwest along Market Street in downtown San Francisco"
             }
         },
         {

--- a/Resources/PreferencesWindow.xib
+++ b/Resources/PreferencesWindow.xib
@@ -2073,7 +2073,7 @@ You can either enter those manually or try to use Location Services on your Mac 
                         <font key="font" metaFont="smallSystem"/>
                         <string key="title">On Power Saving mode, Aerial will no longer play videos. It will show a black screen instead and lower your screen brightness to the minimum.
 
-You can enable it when on battery, or only when your battery reach 20%.</string>
+You can enable it when on battery, or only when your battery reaches 20%.</string>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>


### PR DESCRIPTION
Updated the times in the Embarcadero, Market Street (San Francisco, Day) community descriptions to match the January 2019 version of this video.

Made one grammatical correction to the Power Saving help bubble in the Videos pane (changing the plural form of the verb "to reach" to the singular form to agree with the singular form of the noun "battery").