### PR TITLE
Use Arrow Keys to Advance Video

### DIFF
--- a/Aerial/Source/Views/AerialView.swift
+++ b/Aerial/Source/Views/AerialView.swift
@@ -14,7 +14,7 @@ import Sparkle
 
 @objc(AerialView)
 // swiftlint:disable:next type_body_length
-final class AerialView: ScreenSaverView {
+final class AerialView: ScreenSaverView, NSResponder {
     var playerLayer: AVPlayerLayer!
     var textLayer: CATextLayer!
     var clockLayer: CATextLayer!
@@ -588,6 +588,15 @@ final class AerialView: ScreenSaverView {
                                        name: NSNotification.Name.AVPlayerItemPlaybackStalled,
                                        object: currentItem)
         player.actionAtItemEnd = AVPlayer.ActionAtItemEnd.none
+    }
+    
+    override func keyDown(with event: NSEvent) {
+        switch event.modifierFlags.intersection(.deviceIndependentFlagsMask) {
+        case [.command] where event.characters == NSRightArrowFunctionKey:
+            playNextVideo()
+        default:
+            break
+        }
     }
 
     // MARK: - Extra Animations


### PR DESCRIPTION
Thought it might be interesting to be able to use the right arrow key to advance to the next video. I'm not sure if there are caveats to this in regards to how the videos automatically advance in the queue... but I've added a simple override of the NSResponder's `keyDown:` event, which checks for a press on the right arrow key then calls `playNextVideo()`.

**Edit**: Just saw issue #479 and I'm not sure if this NSResponder interception works in a `ScreenSaverView`? Or if there needs to be a call to super to make sure that other keys are still passed down the event chain? I haven't been able to test the feature as I can't get the build to run with CocoaPods dependencies & Signing issues (any tips there -- I don't see a *Contributing.md* :(?)