### PR TITLE
fix typo

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -32,7 +32,7 @@ Aerial now includes an auto-update mechanism using the [Sparkle open-source proj
 1. Quit **System Preferences**.
 2. [Download the latest release of `Aerial.saver.zip`](https://github.com/JohnCoates/Aerial/releases/latest). Alternatively, you can try the latest beta version [following this link](https://github.com/JohnCoates/Aerial/releases). **(macOS Catalina users, you need the beta version, more information here : https://github.com/JohnCoates/Aerial/issues/801)**
 3. Unzip the downloaded file (if you use Safari, it should already be done for you).
-4. Double-click `Aerial.saver`; it will open in `System Preferences` > `Desktop & Screen Saver` and ask you if you want to install for all users or for your user only. Be aware that installing for all users will require a password at install **and each subsequent update, including auto-updates.** By default, Aerial will still share it's video cache if you install multiple times on the same system for each user.
+4. Double-click `Aerial.saver`; it will open in `System Preferences` > `Desktop & Screen Saver` and ask you if you want to install for all users or for your user only. Be aware that installing for all users will require a password at install **and each subsequent update, including auto-updates.** By default, Aerial will still share its video cache if you install multiple times on the same system for each user.
 
 Need more information on install, setup, or uninstall ? Or want to install via homebrew ? Check our extended [instructions here](Documentation/Installation.md). Curious about auto-updates ? [Have a look here](Documentation/AutoUpdates.md).
 


### PR DESCRIPTION
it's --> its (this usage is not the contraction for "it is" so doesn't need the apostrophe)