### PR TITLE
"True" Mirrored Mode

### DIFF
--- a/Aerial/Source/Controllers/Preferences.swift
+++ b/Aerial/Source/Controllers/Preferences.swift
@@ -95,7 +95,7 @@ final class Preferences {
     }
 
     enum NewViewingMode: Int {
-        case independent, mirrored, spanned
+        case independent, cloned, spanned, mirrored
     }
 
     enum BetaCheckFrequency: Int {

--- a/Aerial/Source/Views/AerialView.swift
+++ b/Aerial/Source/Views/AerialView.swift
@@ -404,6 +404,12 @@ final class AerialView: ScreenSaverView, CAAnimationDelegate {
             }
         } else {
             playerLayer.frame = layer.bounds
+
+            let index = AerialView.instanciatedViews.firstIndex(of: self) ?? 0
+
+            if index % 2 == 1 {
+                playerLayer.transform = CATransform3DMakeAffineTransform(CGAffineTransform(scaleX: -1, y: 1))
+            }
         }
         layer.addSublayer(playerLayer)
 

--- a/Aerial/Source/Views/AerialView.swift
+++ b/Aerial/Source/Views/AerialView.swift
@@ -77,8 +77,17 @@ final class AerialView: ScreenSaverView, CAAnimationDelegate {
     // Mirrored viewing mode and Spanned viewing mode share the same player for sync & ressource saving
     static var sharingPlayers: Bool {
         let preferences = Preferences.sharedInstance
-        return (preferences.newViewingMode == Preferences.NewViewingMode.mirrored.rawValue) ||
-            (preferences.newViewingMode == Preferences.NewViewingMode.spanned.rawValue)
+
+        switch preferences.newViewingMode {
+        case
+            Preferences.NewViewingMode.cloned.rawValue,
+            Preferences.NewViewingMode.mirrored.rawValue,
+            Preferences.NewViewingMode.spanned.rawValue:
+
+            return true
+        default:
+            return false
+        }
     }
 
     static var sharedViews: [AerialView] = []
@@ -406,8 +415,7 @@ final class AerialView: ScreenSaverView, CAAnimationDelegate {
             playerLayer.frame = layer.bounds
 
             let index = AerialView.instanciatedViews.firstIndex(of: self) ?? 0
-
-            if index % 2 == 1 {
+            if index % 2 == 1 && preferences.newViewingMode == Preferences.NewViewingMode.mirrored.rawValue {
                 playerLayer.transform = CATransform3DMakeAffineTransform(CGAffineTransform(scaleX: -1, y: 1))
             }
         }

--- a/Aerial/Source/Views/DisplayView.swift
+++ b/Aerial/Source/Views/DisplayView.swift
@@ -19,6 +19,27 @@ class DisplayPreview: NSObject {
     }
 }
 
+extension NSImage {
+    func flipped(flipHorizontally: Bool = false, flipVertically: Bool = false) -> NSImage {
+        let flippedImage = NSImage(size: size)
+
+        flippedImage.lockFocus()
+
+        NSGraphicsContext.current?.imageInterpolation = .high
+
+        let transform = NSAffineTransform()
+        transform.translateX(by: flipHorizontally ? size.width : 0, yBy: flipVertically ? size.height : 0)
+        transform.scaleX(by: flipHorizontally ? -1 : 1, yBy: flipVertically ? -1 : 1)
+        transform.concat()
+
+        draw(at: .zero, from: NSRect(origin: .zero, size: size), operation: .sourceOver, fraction: 1)
+
+        flippedImage.unlockFocus()
+
+        return flippedImage
+    }
+}
+
 class DisplayView: NSView {
     // We store our computed previews here
     var displayPreviews = [DisplayPreview]()
@@ -115,13 +136,19 @@ class DisplayView: NSView {
 
             let sInRect = sRect.insetBy(dx: 1, dy: 1)
 
-            if preferences.newViewingMode == Preferences.NewViewingMode.independent.rawValue ||
-                preferences.newViewingMode == Preferences.NewViewingMode.mirrored.rawValue {
+            func rawValue(for mode: Preferences.NewViewingMode) -> Int { return mode.rawValue }
+            let viewMode = preferences.newViewingMode
+
+            if viewMode == rawValue(for: .independent) || viewMode == rawValue(for: .cloned) || viewMode == rawValue(for: .mirrored) {
                 if displayDetection.isScreenActive(id: screen.id) {
                     let bundle = Bundle(for: PreferencesWindowController.self)
                     if let imagePath = bundle.path(forResource: "screen"+String(idx), ofType: "jpg") {
-                        let image = NSImage(contentsOfFile: imagePath)
-                        //image!.draw(in: sInRect)
+                        var image = NSImage(contentsOfFile: imagePath)
+
+                        if preferences.newViewingMode == Preferences.NewViewingMode.mirrored.rawValue && screen.id % 2 == 1 {
+                            image = image?.flipped(flipHorizontally: true, flipVertically: false)
+                        }
+
                         image!.draw(in: sInRect, from: calcScreenshotRect(src: sInRect), operation: NSCompositingOperation.copy, fraction: 1.0)
                     } else {
                         errorLog("\(#file) screenshot is missing!!!")

--- a/Resources/PreferencesWindow.xib
+++ b/Resources/PreferencesWindow.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="15504" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="15400" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.AVKitIBPlugin" version="15504"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15504"/>
+        <plugIn identifier="com.apple.AVKitIBPlugin" version="15400"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15400"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -522,7 +522,7 @@ is disabled
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <buttonCell key="cell" type="roundRect" bezelStyle="roundedRect" image="NSBookmarksTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="kGs-X6-tPb">
                                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                        <font key="font" metaFont="controlContent"/>
+                                                        <font key="font" metaFont="label" size="12"/>
                                                     </buttonCell>
                                                     <connections>
                                                         <action selector="videoSetsButtonClick:" target="-2" id="aDh-Hf-5AD"/>
@@ -544,7 +544,7 @@ is disabled
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <buttonCell key="cell" type="roundRect" bezelStyle="roundedRect" image="NSActionTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="nxM-5Y-pQM">
                                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                        <font key="font" metaFont="controlContent"/>
+                                                        <font key="font" metaFont="label" size="12"/>
                                                     </buttonCell>
                                                     <connections>
                                                         <action selector="outlineViewSettingsClick:" target="-2" id="foF-Fr-895"/>
@@ -565,7 +565,7 @@ is disabled
                                         </view>
                                     </tabViewItem>
                                     <tabViewItem label="Displays" identifier="" id="P6g-Pf-AmY">
-                                        <view key="view" id="65A-Ae-cVB">
+                                        <view key="view" ambiguous="YES" id="65A-Ae-cVB">
                                             <rect key="frame" x="10" y="33" width="614" height="381"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
@@ -648,8 +648,13 @@ is disabled
                                                         <menu key="menu" id="3Bi-za-9u6">
                                                             <items>
                                                                 <menuItem title="Independent" state="on" id="MKb-uC-u8v"/>
-                                                                <menuItem title="Mirrored" id="mW5-ZK-gX1"/>
+                                                                <menuItem title="Cloned" id="mW5-ZK-gX1" userLabel="Cloned">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                </menuItem>
                                                                 <menuItem title="Spanned" id="1hP-Py-Qcq">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                </menuItem>
+                                                                <menuItem title="Mirrored" id="3ls-5j-yRy" userLabel="Mirrored">
                                                                     <modifierMask key="keyEquivalentModifierMask"/>
                                                                 </menuItem>
                                                             </items>
@@ -1773,7 +1778,7 @@ Shift, but macOS 10.12.4 or above and a compatible Mac are required) </string>
                                         </view>
                                     </tabViewItem>
                                     <tabViewItem label="Updates" identifier="" id="7Rb-Ma-4dK">
-                                        <view key="view" ambiguous="YES" id="2qs-gJ-aIh">
+                                        <view key="view" id="2qs-gJ-aIh">
                                             <rect key="frame" x="10" y="33" width="614" height="381"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
@@ -2289,7 +2294,7 @@ Gw
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <clipView key="contentView" ambiguous="YES" id="rFk-xj-xKP">
                             <rect key="frame" x="1" y="1" width="659" height="337"/>
-                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                            <autoresizingMask key="autoresizingMask"/>
                             <subviews>
                                 <tableView verticalHuggingPriority="750" ambiguous="YES" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnSelection="YES" multipleSelection="NO" autosaveColumns="NO" viewBased="YES" id="btT-0Y-wSk">
                                     <rect key="frame" x="0.0" y="0.0" width="659" height="337"/>


### PR DESCRIPTION
This PR add support to "true" mirrored mode where the image on odd displays is flipped horizontally. The old "mirrored" mode has been renamed to "cloned".

Existing users will have to manually switch to the new mirroring behavior otherwise they will stay in the old mode. 

Here's some previews:
![Screenshot 2019-10-17 at 13 30 48](https://user-images.githubusercontent.com/2745656/67006039-6210f900-f0e4-11e9-8296-140fc536bfb6.png)
![Screenshot 2019-10-17 at 13 30 45](https://user-images.githubusercontent.com/2745656/67006040-6210f900-f0e4-11e9-9d7e-5112b619f472.png)
