### PR TITLE
1.6.4

### DIFF
--- a/Aerial.xcodeproj/project.pbxproj
+++ b/Aerial.xcodeproj/project.pbxproj
@@ -1185,7 +1185,7 @@
 				CODE_SIGN_IDENTITY = "Developer ID Application: Guillaume Louel (3L54M5L5KK)";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1.6.2;
+				CURRENT_PROJECT_VERSION = 1.6.3test2;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 3L54M5L5KK;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -1193,7 +1193,7 @@
 				INSTALL_PATH = "$(HOME)/Library/Screen Savers";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				MARKETING_VERSION = 1.6.2;
+				MARKETING_VERSION = 1.6.3test2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.johncoates.Aerial;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1214,7 +1214,7 @@
 				CODE_SIGN_IDENTITY = "Developer ID Application: Guillaume Louel (3L54M5L5KK)";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1.6.2;
+				CURRENT_PROJECT_VERSION = 1.6.3test2;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 3L54M5L5KK;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -1222,7 +1222,7 @@
 				INSTALL_PATH = "$(HOME)/Library/Screen Savers";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				MARKETING_VERSION = 1.6.2;
+				MARKETING_VERSION = 1.6.3test2;
 				OTHER_CODE_SIGN_FLAGS = "--timestamp";
 				PRODUCT_BUNDLE_IDENTIFIER = com.johncoates.Aerial;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Aerial.xcodeproj/project.pbxproj
+++ b/Aerial.xcodeproj/project.pbxproj
@@ -995,7 +995,7 @@
 				INFOPLIST_FILE = Aerial/App/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				MARKETING_VERSION = 1.6.3;
+				MARKETING_VERSION = 1.6.4;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.johncoates.Aerial-Test";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1018,7 +1018,7 @@
 				INFOPLIST_FILE = Aerial/App/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				MARKETING_VERSION = 1.6.3;
+				MARKETING_VERSION = 1.6.4;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.johncoates.Aerial-Test";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1185,7 +1185,7 @@
 				CODE_SIGN_IDENTITY = "Developer ID Application: Guillaume Louel (3L54M5L5KK)";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1.6.3;
+				CURRENT_PROJECT_VERSION = 1.6.4;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 3L54M5L5KK;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -1193,7 +1193,7 @@
 				INSTALL_PATH = "$(HOME)/Library/Screen Savers";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				MARKETING_VERSION = 1.6.3;
+				MARKETING_VERSION = 1.6.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.johncoates.Aerial;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1214,7 +1214,7 @@
 				CODE_SIGN_IDENTITY = "Developer ID Application: Guillaume Louel (3L54M5L5KK)";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1.6.3;
+				CURRENT_PROJECT_VERSION = 1.6.4;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 3L54M5L5KK;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -1222,7 +1222,7 @@
 				INSTALL_PATH = "$(HOME)/Library/Screen Savers";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				MARKETING_VERSION = 1.6.3;
+				MARKETING_VERSION = 1.6.4;
 				OTHER_CODE_SIGN_FLAGS = "--timestamp";
 				PRODUCT_BUNDLE_IDENTIFIER = com.johncoates.Aerial;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Aerial.xcodeproj/project.pbxproj
+++ b/Aerial.xcodeproj/project.pbxproj
@@ -995,7 +995,7 @@
 				INFOPLIST_FILE = Aerial/App/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				MARKETING_VERSION = 1.6.0;
+				MARKETING_VERSION = 1.6.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.johncoates.Aerial-Test";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1018,7 +1018,7 @@
 				INFOPLIST_FILE = Aerial/App/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				MARKETING_VERSION = 1.6.0;
+				MARKETING_VERSION = 1.6.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.johncoates.Aerial-Test";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1185,7 +1185,7 @@
 				CODE_SIGN_IDENTITY = "Developer ID Application: Guillaume Louel (3L54M5L5KK)";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1.6.3test2;
+				CURRENT_PROJECT_VERSION = 1.6.3;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 3L54M5L5KK;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -1193,7 +1193,7 @@
 				INSTALL_PATH = "$(HOME)/Library/Screen Savers";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				MARKETING_VERSION = 1.6.3test2;
+				MARKETING_VERSION = 1.6.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.johncoates.Aerial;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1214,7 +1214,7 @@
 				CODE_SIGN_IDENTITY = "Developer ID Application: Guillaume Louel (3L54M5L5KK)";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1.6.3test2;
+				CURRENT_PROJECT_VERSION = 1.6.3;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 3L54M5L5KK;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -1222,7 +1222,7 @@
 				INSTALL_PATH = "$(HOME)/Library/Screen Savers";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				MARKETING_VERSION = 1.6.3test2;
+				MARKETING_VERSION = 1.6.3;
 				OTHER_CODE_SIGN_FLAGS = "--timestamp";
 				PRODUCT_BUNDLE_IDENTIFIER = com.johncoates.Aerial;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Aerial/Source/Controllers/PWC Tabs/PWC+Cache.swift
+++ b/Aerial/Source/Controllers/PWC Tabs/PWC+Cache.swift
@@ -30,8 +30,8 @@ extension PreferencesWindowController {
     }
 
     func updateCacheSize() {
-        // get your directory url
-        let documentsDirectoryURL = URL(fileURLWithPath: VideoCache.cacheDirectory!)
+        // get your directory url, we now use App support
+        let documentsDirectoryURL = URL(fileURLWithPath: VideoCache.appSupportDirectory!)
 
         // FileManager.default.urls(for: VideoCache.cacheDirectory, in: .userDomainMask).first!
 

--- a/Aerial/Source/Controllers/PWC Tabs/PWC+Videos.swift
+++ b/Aerial/Source/Controllers/PWC Tabs/PWC+Videos.swift
@@ -187,6 +187,10 @@ extension PreferencesWindowController {
         popoverPower.show(relativeTo: button.preparedContentRect, of: button, preferredEdge: .maxY)
     }
 
+    @IBAction func helpHDRButtonClick(_ button: NSButton) {
+        popoverHDR.show(relativeTo: button.preparedContentRect, of: button, preferredEdge: .maxY)
+    }
+
     @IBAction func fadeInOutModePopupChange(_ sender: NSPopUpButton) {
         debugLog("UI fadeInOutMode: \(sender.indexOfSelectedItem)")
         preferences.fadeMode = sender.indexOfSelectedItem
@@ -239,6 +243,13 @@ extension PreferencesWindowController {
             let videoManager = VideoManager.sharedInstance
             videoManager.updateAllCheckCellView()
         }
+    }
+
+    // MARK: Wikipedia popup link
+    @IBAction func linkToWikipediaDolbyVisionClick(_ sender: Any) {
+        let workspace = NSWorkspace.shared
+        let url = URL(string: "https://en.wikipedia.org/wiki/Dolby_Laboratories#Video_processing")!
+        workspace.open(url)
     }
 
     // MARK: Video playback

--- a/Aerial/Source/Controllers/PreferencesWindowController.swift
+++ b/Aerial/Source/Controllers/PreferencesWindowController.swift
@@ -34,6 +34,8 @@ final class PreferencesWindowController: NSWindowController, NSOutlineViewDataSo
     @IBOutlet var popoverHEVCLabel: NSTextField!
     @IBOutlet var secondProjectPageLink: NSButton!
 
+    @IBOutlet var popoverHDR: NSPopover!
+
     @IBOutlet var popoverTime: NSPopover!
     @IBOutlet var linkTimeWikipediaButton: NSButton!
 
@@ -252,7 +254,6 @@ final class PreferencesWindowController: NSWindowController, NSOutlineViewDataSo
         return formatter
     }()
 
-    // MARK: - Init
     required init?(coder decoder: NSCoder) {
         self.fontManager = NSFontManager.shared
         debugLog("pwc init1")

--- a/Aerial/Source/Controllers/PreferencesWindowController.swift
+++ b/Aerial/Source/Controllers/PreferencesWindowController.swift
@@ -501,6 +501,8 @@ final class PreferencesWindowController: NSWindowController, NSOutlineViewDataSo
             self.outlineView.reloadData()
             self.outlineView.expandItem(nil, expandChildren: true)
         }
+
+        // We update the info in the advanced tab
         let (description, total) = ManifestLoader.instance.getOldFilesEstimation()
         videoVersionsLabel.stringValue = description
         if total > 0 {

--- a/Aerial/Source/Models/ErrorLog.swift
+++ b/Aerial/Source/Models/ErrorLog.swift
@@ -55,7 +55,7 @@ func Log(level: ErrorLevel, message: String) {
         if #available(OSX 10.12, *) {
             // This is faster when available
             let log = OSLog(subsystem: Bundle.main.bundleIdentifier!, category: "Screensaver")
-            os_log("AerialError: %@", log: log, type: .error, message)
+            os_log("AerialError: %{public}@", log: log, type: .error, message)
         } else {
             NSLog("AerialError: \(message)")
         }

--- a/Aerial/Source/Models/ManifestLoader.swift
+++ b/Aerial/Source/Models/ManifestLoader.swift
@@ -902,7 +902,7 @@ class ManifestLoader {
             warnLog("We have no videos in the manifest")
             return ("Can't estimate duplicates", 0)
         }
-        guard let cacheDirectory = VideoCache.cacheDirectory else {
+        guard let cacheDirectory = VideoCache.appSupportDirectory else {
             warnLog("No cache directory")
             return ("Can't estimate duplicates", 0)
         }
@@ -915,7 +915,7 @@ class ManifestLoader {
             let directoryContent = try fileManager.contentsOfDirectory(at: cacheDirectoryUrl, includingPropertiesForKeys: nil)
             let videoFileURLs = directoryContent.filter { $0.pathExtension == "mov" }
 
-            // We check the 3 fields
+            // We check the 5 fields
             for fileURL in videoFileURLs {
                 var found = false
                 for video in loadedManifest {
@@ -931,8 +931,20 @@ class ManifestLoader {
                             break
                         }
                     }
+                    if video.url1080pHDR != "" {
+                        if fileURL.lastPathComponent == URL(string: video.url1080pHDR)?.lastPathComponent {
+                            found = true
+                            break
+                        }
+                    }
                     if video.url4KHEVC != "" {
                         if fileURL.lastPathComponent == URL(string: video.url4KHEVC)?.lastPathComponent {
+                            found = true
+                            break
+                        }
+                    }
+                    if video.url4KHDR != "" {
+                        if fileURL.lastPathComponent == URL(string: video.url4KHDR)?.lastPathComponent {
                             found = true
                             break
                         }
@@ -992,7 +1004,7 @@ class ManifestLoader {
             let directoryContent = try fileManager.contentsOfDirectory(at: cacheDirectoryUrl, includingPropertiesForKeys: nil)
             let videoFileURLs = directoryContent.filter { $0.pathExtension == "mov" }
 
-            // We check the 3 fields
+            // We check the 5 fields
             for fileURL in videoFileURLs {
                 var found = false
                 for video in loadedManifest {
@@ -1008,8 +1020,20 @@ class ManifestLoader {
                             break
                         }
                     }
+                    if video.url1080pHDR != "" {
+                        if fileURL.lastPathComponent == URL(string: video.url1080pHDR)?.lastPathComponent {
+                            found = true
+                            break
+                        }
+                    }
                     if video.url4KHEVC != "" {
                         if fileURL.lastPathComponent == URL(string: video.url4KHEVC)?.lastPathComponent {
+                            found = true
+                            break
+                        }
+                    }
+                    if video.url4KHDR != "" {
+                        if fileURL.lastPathComponent == URL(string: video.url4KHDR)?.lastPathComponent {
                             found = true
                             break
                         }
@@ -1034,7 +1058,7 @@ class ManifestLoader {
     // swiftlint:disable:next cyclomatic_complexity
     func trashOldVideos() {
         debugLog("trash old videos")
-        let cacheDirectory = VideoCache.cacheDirectory!
+        let cacheDirectory = VideoCache.appSupportDirectory!
         var cacheResourcesString = cacheDirectory
 
         let dateFormatter = DateFormatter()
@@ -1067,7 +1091,7 @@ class ManifestLoader {
             let directoryContent = try fileManager.contentsOfDirectory(at: cacheDirectoryUrl, includingPropertiesForKeys: nil)
             let videoFileURLs = directoryContent.filter { $0.pathExtension == "mov" }
 
-            // We check the 3 fields
+            // We check the 5 fields
             for fileURL in videoFileURLs {
                 var found = false
                 for video in loadedManifest {
@@ -1083,8 +1107,20 @@ class ManifestLoader {
                             break
                         }
                     }
+                    if video.url1080pHDR != "" {
+                        if fileURL.lastPathComponent == URL(string: video.url1080pHDR)?.lastPathComponent {
+                            found = true
+                            break
+                        }
+                    }
                     if video.url4KHEVC != "" {
                         if fileURL.lastPathComponent == URL(string: video.url4KHEVC)?.lastPathComponent {
+                            found = true
+                            break
+                        }
+                    }
+                    if video.url4KHDR != "" {
+                        if fileURL.lastPathComponent == URL(string: video.url4KHDR)?.lastPathComponent {
                             found = true
                             break
                         }

--- a/Aerial/Source/Models/ManifestLoader.swift
+++ b/Aerial/Source/Models/ManifestLoader.swift
@@ -455,10 +455,10 @@ class ManifestLoader {
                                                 type: "video",
                                                 timeOfDay: asset.time,
                                                 url1080pH264: url1080p,
-                                                url1080pHEVC: "",
-                                                url1080pHDR: "",
+                                                url1080pHEVC: url1080p,
+                                                url1080pHDR: url1080p,
                                                 url4KHEVC: url4K,
-                                                url4KHDR: "",
+                                                url4KHDR: url4K,
                                                 manifest: .customVideos,
                                                 poi: [:],
                                                 communityPoi: asset.pointsOfInterest)
@@ -765,7 +765,7 @@ class ManifestLoader {
                 }
             }
         } catch {
-            errorLog("Error retrieving content listing")
+            errorLog("Error retrieving content listing (new)")
             return
         }
     }
@@ -850,7 +850,7 @@ class ManifestLoader {
                 }
             }
         } catch {
-            errorLog("Error retrieving content listing")
+            errorLog("Error retrieving content listing (old)")
             return
         }
     }

--- a/Resources/PreferencesWindow.xib
+++ b/Resources/PreferencesWindow.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="15504" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="15505" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.AVKitIBPlugin" version="15504"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15504"/>
+        <plugIn identifier="com.apple.AVKitIBPlugin" version="15505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15505"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -111,6 +111,7 @@
                 <outlet property="popover" destination="vZt-x4-E4Y" id="Zd6-gn-9G8"/>
                 <outlet property="popoverH264Indicator" destination="Eiy-rf-14s" id="ZGO-KJ-0wF"/>
                 <outlet property="popoverH264Label" destination="Ynp-31-Ohm" id="CbV-4g-iai"/>
+                <outlet property="popoverHDR" destination="A29-dm-TEK" id="GmG-fb-JsU"/>
                 <outlet property="popoverHEVCIndicator" destination="Kzc-o6-MCY" id="TxU-h9-Jx0"/>
                 <outlet property="popoverHEVCLabel" destination="RGL-6I-5Hp" id="Fgt-8f-0Vb"/>
                 <outlet property="popoverPower" destination="7lP-6F-c7D" id="Ozn-hU-sAe"/>
@@ -175,7 +176,7 @@
                                 <font key="font" metaFont="system"/>
                                 <tabViewItems>
                                     <tabViewItem label="Videos" identifier="1" id="dfl-QA-fvD">
-                                        <view key="view" id="zsM-Ha-kCO">
+                                        <view key="view" ambiguous="YES" id="zsM-Ha-kCO">
                                             <rect key="frame" x="10" y="33" width="614" height="381"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
@@ -514,15 +515,15 @@ is disabled
                                                         <font key="font" metaFont="system"/>
                                                     </buttonCell>
                                                     <connections>
-                                                        <action selector="helpPowerButtonClick:" target="-2" id="IoR-ba-SVJ"/>
+                                                        <action selector="helpPowerButtonClick:" target="-2" id="oku-o3-QZw"/>
                                                     </connections>
                                                 </button>
-                                                <button toolTip="Option menu" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3ly-5z-7Yd">
+                                                <button toolTip="Video Sets" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3ly-5z-7Yd">
                                                     <rect key="frame" x="52" y="10" width="32" height="19"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <buttonCell key="cell" type="roundRect" bezelStyle="roundedRect" image="NSBookmarksTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="kGs-X6-tPb">
                                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                        <font key="font" metaFont="controlContent"/>
+                                                        <font key="font" metaFont="system" size="12"/>
                                                     </buttonCell>
                                                     <connections>
                                                         <action selector="videoSetsButtonClick:" target="-2" id="aDh-Hf-5AD"/>
@@ -544,21 +545,32 @@ is disabled
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <buttonCell key="cell" type="roundRect" bezelStyle="roundedRect" image="NSActionTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="nxM-5Y-pQM">
                                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                        <font key="font" metaFont="controlContent"/>
+                                                        <font key="font" metaFont="system" size="12"/>
                                                     </buttonCell>
                                                     <connections>
                                                         <action selector="outlineViewSettingsClick:" target="-2" id="foF-Fr-895"/>
                                                     </connections>
                                                 </button>
                                                 <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jod-Zd-q4b">
-                                                    <rect key="frame" x="307" y="118" width="307" height="18"/>
+                                                    <rect key="frame" x="307" y="118" width="227" height="18"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                    <buttonCell key="cell" type="check" title="Use HDR if available (requires macOS Catalina)" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="zwG-lv-nkj">
+                                                    <buttonCell key="cell" type="check" title="Download HDR versions of videos" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="zwG-lv-nkj">
                                                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                         <font key="font" metaFont="system"/>
                                                     </buttonCell>
                                                     <connections>
                                                         <action selector="useHDRChange:" target="-2" id="dDv-tU-zM3"/>
+                                                    </connections>
+                                                </button>
+                                                <button toolTip="Click for more information on HDR (High Dynamic Range)" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pUM-TN-b6p">
+                                                    <rect key="frame" x="576" y="114" width="21" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                    <buttonCell key="cell" type="help" bezelStyle="helpButton" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="NyN-ty-9y3">
+                                                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                        <font key="font" metaFont="system"/>
+                                                    </buttonCell>
+                                                    <connections>
+                                                        <action selector="helpHDRButtonClick:" target="-2" id="E0B-ag-g29"/>
                                                     </connections>
                                                 </button>
                                             </subviews>
@@ -1773,7 +1785,7 @@ Shift, but macOS 10.12.4 or above and a compatible Mac are required) </string>
                                         </view>
                                     </tabViewItem>
                                     <tabViewItem label="Updates" identifier="" id="7Rb-Ma-4dK">
-                                        <view key="view" ambiguous="YES" id="2qs-gJ-aIh">
+                                        <view key="view" id="2qs-gJ-aIh">
                                             <rect key="frame" x="10" y="33" width="614" height="381"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
@@ -2289,7 +2301,7 @@ Gw
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <clipView key="contentView" ambiguous="YES" id="rFk-xj-xKP">
                             <rect key="frame" x="1" y="1" width="659" height="337"/>
-                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                            <autoresizingMask key="autoresizingMask"/>
                             <subviews>
                                 <tableView verticalHuggingPriority="750" ambiguous="YES" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnSelection="YES" multipleSelection="NO" autosaveColumns="NO" viewBased="YES" id="btT-0Y-wSk">
                                     <rect key="frame" x="0.0" y="0.0" width="659" height="337"/>
@@ -2804,7 +2816,7 @@ Unless you want to manually manage your updates, we highly recommand you leave t
                     </textFieldCell>
                 </textField>
             </subviews>
-            <point key="canvasLocation" x="1218.5" y="559"/>
+            <point key="canvasLocation" x="1611" y="584"/>
         </customView>
         <window title="Video downloads in progress" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" hidesOnDeactivate="YES" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" id="qE0-Sq-kqZ" customClass="NSPanel">
             <windowStyleMask key="styleMask" titled="YES" utility="YES"/>
@@ -2982,6 +2994,50 @@ After changing the folder, please close System Preferences for this to be taken 
             </view>
             <point key="canvasLocation" x="947" y="1375"/>
         </window>
+        <viewController id="VKe-Nh-9kL" userLabel="Popover View Controller">
+            <connections>
+                <outlet property="view" destination="M2z-5I-be7" id="TMu-uv-Vic"/>
+            </connections>
+        </viewController>
+        <popover behavior="t" id="A29-dm-TEK">
+            <connections>
+                <outlet property="contentViewController" destination="VKe-Nh-9kL" id="dgd-iI-USS"/>
+            </connections>
+        </popover>
+        <customView id="M2z-5I-be7">
+            <rect key="frame" x="0.0" y="0.0" width="428" height="245"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+            <subviews>
+                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="PbK-lK-el9">
+                    <rect key="frame" x="53" y="20" width="334" height="25"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <buttonCell key="cell" type="bevel" title="More information about Dolby Vision on Wikipedia" bezelStyle="rounded" alignment="center" refusesFirstResponder="YES" inset="2" id="pDb-QQ-qL8">
+                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                        <font key="font" metaFont="message" size="11"/>
+                        <connections>
+                            <action selector="linkToWikipediaDolbyVisionClick:" target="-2" id="fdV-mE-dxT"/>
+                        </connections>
+                    </buttonCell>
+                </button>
+                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3fd-p3-gWo">
+                    <rect key="frame" x="18" y="44" width="392" height="182"/>
+                    <autoresizingMask key="autoresizingMask"/>
+                    <textFieldCell key="cell" selectable="YES" id="YN8-HP-dRv">
+                        <font key="font" metaFont="message" size="11"/>
+                        <mutableString key="title">If you enable HDR, Aerial will download new versions of the videos. This option is only available starting with macOS Catalina.
+
+These videos are using Dolby Vision to represent a Higher Dynamic Range of colors and lighting. 
+
+In practice, this means you will see wilder colors which may or may not look pleasing or realistic to you. 
+
+Please note that all 4K videos are encoded in 10 bit per color component, whether you are using HDR or not. Those files will be played appropriately whether your screen is 10 bit (iMac) or 8 bit (Macbook Pro).</mutableString>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+            </subviews>
+            <point key="canvasLocation" x="608" y="1168.5"/>
+        </customView>
     </objects>
     <resources>
         <image name="NSActionTemplate" width="14" height="14"/>


### PR DESCRIPTION
- Clarify what HDR means with a popup and clearly say that those are separate files and not just a rendering mode
- Fix cache size detection that still looked in the read only cache folder in Catalina instead of appSupport
- Fix an incorrect tooltip for Video Sets
- Fix old files estimation, move/trash old videos features that would always delete HDR files, and would look in the wrong folder in Catalina.