### PR TITLE
Fixed PreferencesWindow radio button tool tips

### DIFF
--- a/Resources/PreferencesWindow.xib
+++ b/Resources/PreferencesWindow.xib
@@ -2913,7 +2913,7 @@ After changing the folder, please close System Preferences for this to be taken 
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" imageFrameStyle="groove" image="screen0" id="wB2-iW-iua"/>
                 </imageView>
-                <button toolTip="Bottom left corner" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="EqM-n4-opf">
+                <button toolTip="Top left corner" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="EqM-n4-opf">
                     <rect key="frame" x="122" y="165" width="22" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="radio" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="cUG-A6-9om">
@@ -2946,7 +2946,7 @@ After changing the folder, please close System Preferences for this to be taken 
                         <action selector="changePosition:" target="ls3-ia-gMN" id="OZs-BQ-Owq"/>
                     </connections>
                 </button>
-                <button toolTip="Top left corner" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="aRt-Pt-u4B">
+                <button toolTip="Centre" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="aRt-Pt-u4B">
                     <rect key="frame" x="193" y="130" width="22" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="radio" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="apK-I5-qUa">
@@ -2968,7 +2968,7 @@ After changing the folder, please close System Preferences for this to be taken 
                         <action selector="changePosition:" target="ls3-ia-gMN" id="JTt-5y-iiv"/>
                     </connections>
                 </button>
-                <button toolTip="Top left corner" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="TYL-NO-mBq">
+                <button toolTip="Top middle edge" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="TYL-NO-mBq">
                     <rect key="frame" x="193" y="165" width="22" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="radio" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="3Pa-Qv-e2x">
@@ -2979,7 +2979,7 @@ After changing the folder, please close System Preferences for this to be taken 
                         <action selector="changePosition:" target="ls3-ia-gMN" id="ghv-GE-4Tn"/>
                     </connections>
                 </button>
-                <button toolTip="Bottom left corner" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MG8-J5-mQV">
+                <button toolTip="Bottom middle edge" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MG8-J5-mQV">
                     <rect key="frame" x="193" y="95" width="22" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="radio" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="7dh-x8-ZE3">


### PR DESCRIPTION
A few radio buttons in the Aerial preferences -> Info -> Position have incorrect tool tips (copy-paste much?). This fixes those issues.