### PR TITLE
Fix troubleshooting page URL.

### DIFF
--- a/issue_template.md
+++ b/issue_template.md
@@ -3,7 +3,7 @@
 Before logging an issue please check that:
 - [ ] You have the latest version installed (There may be a beta version that fixes your issue), see here for the latest releases and bug fixes: https://github.com/JohnCoates/Aerial/releases
 - [ ] Your issue isn't already mentioned in our [issues](https://github.com/JohnCoates/Aerial/issues). You may find a workaround there or a similar request already made.
-- [ ] Your problem isn't mentioned in the [troubleshooting section](https://github.com/JohnCoates/Aerial#troubleshooting).
+- [ ] Your problem isn't mentioned in the [troubleshooting page](https://github.com/JohnCoates/Aerial/blob/master/Documentation/Troubleshooting.md).
 
 If none of this fixes your issue, tell us about the problem you are experiencing or the feature you'd like to request.
 


### PR DESCRIPTION
Troubleshooting reference in Github issues template is old. Let's point to the brand new page dedicated to troubleshooting.