### PR TITLE
docs: Fix brew commands in Installation.md

### DIFF
--- a/Documentation/Installation.md
+++ b/Documentation/Installation.md
@@ -24,13 +24,13 @@ If you're looking to install Aerial across many systems, remotely, or simply fro
 Simply issue the following Terminal command:
 
 ```sh
-brew cask install aerial
+brew install --cask aerial
 ```
 
 To upgrade Aerial, run the following Terminal command:
 
 ```sh
-brew cask upgrade aerial
+brew upgrade --cask aerial
 ```
 
 Please note that if you prefer using homebrew to update Aerial, we recommend you disable Sparkle auto updates in the `Updates`tab. 
@@ -55,7 +55,7 @@ There are three ways to uninstall Aerial from your Mac. However please first rea
 - If you installed Aerial using Brew Cask, then enter the following command in a Terminal window to uninstall:
 
 ```sh
-brew cask uninstall aerial
+brew uninstall --cask aerial
 ```
 
 # Removing the cache 


### PR DESCRIPTION
`brew cask` commands are in https://aerialscreensaver.github.io/installation.html, but these doesn't work now because of update of Homebrew.

homebrew blog: [2.6.0 — Homebrew](https://brew.sh/2020/12/01/homebrew-2.6.0/)

> All brew cask commands have been deprecated in favour of brew commands (with --cask) when necessary

screenshot:

![Calling brew cask install is disabled](https://user-images.githubusercontent.com/8146876/103965666-95d0b680-51a1-11eb-9bf8-cedd61cbdfdd.png)
