### PR TITLE
Unbreak build straight from Git

### DIFF
--- a/Aerial/Source/Models/API/APISecrets.swift
+++ b/Aerial/Source/Models/API/APISecrets.swift
@@ -13,6 +13,8 @@ import Foundation
 // and still let them be used for everyone in the officially distributed Aerial.
 
 struct APISecrets {
+    static let appleMusicToken = "all"
+    static let openWeatherAppId = "secrets"
     static let yahooAppId = "intentionally"
     static let yahooClientId = "left"
     static let yahooClientSecret = "empty!"


### PR DESCRIPTION
Currently, any attempt to build the sources from Git will fail due to missing fields in `APISecrets`.