### PR TITLE
Allow symlinks for local videos

### DIFF
--- a/Aerial/Source/Models/Cache/VideoCache.swift
+++ b/Aerial/Source/Models/Cache/VideoCache.swift
@@ -145,23 +145,7 @@ final class VideoCache {
         let fileManager = FileManager.default
 
         if video.url.absoluteString.starts(with: "file") {
-            if fileManager.fileExists(atPath: video.url.path) {
-                do {
-                    let resourceValues = try video.url.resourceValues(forKeys: [.fileSizeKey])
-                    let fileSize = resourceValues.fileSize!
-
-                    // Make sure the file is big enough to be a video and not some network failure
-                    if fileSize > 500000 {
-                        return true
-                    }
-                } catch {
-                    errorLog("File check throw")
-                }
-
-                return false
-            } else {
-                return false
-            }
+            return fileManager.fileExists(atPath: video.url.path)
         } else {
             if video.source.isCachable {
                 guard let videoCachePath = cachePath(forVideo: video) else {

--- a/Aerial/Source/Models/Sources/SourceList.swift
+++ b/Aerial/Source/Models/Sources/SourceList.swift
@@ -261,11 +261,13 @@ struct SourceList {
                 
                 for lurl in urls {
                     if lurl.path.lowercased().hasSuffix(".mp4") || lurl.path.lowercased().hasSuffix(".mov") {
-                        
+                        let fileManager = FileManager.default
+                        let attributes = try? fileManager.attributesOfItem(atPath: lurl.path)
+                        let fileType = attributes?[.type] as? FileAttributeType
                         let resourceValues = try lurl.resourceValues(forKeys: [.fileSizeKey])
                         let fileSize = resourceValues.fileSize!
 
-                        if fileSize > 500000 {
+                        if fileSize > 500000 || fileType == .typeSymbolicLink {
                             // Check if the asset was there previously
                             let foundAssets = originalAssets.filter { $0.url4KSDR == lurl.path }
 
@@ -323,11 +325,13 @@ struct SourceList {
 
             for lurl in urls {
                 if lurl.path.lowercased().hasSuffix(".mp4") || lurl.path.lowercased().hasSuffix(".mov") {
-                    
+                    let fileManager = FileManager.default
+                    let attributes = try? fileManager.attributesOfItem(atPath: lurl.path)
+                    let fileType = attributes?[.type] as? FileAttributeType
                     let resourceValues = try lurl.resourceValues(forKeys: [.fileSizeKey])
                     let fileSize = resourceValues.fileSize!
 
-                    if fileSize > 500000 {
+                    if fileSize > 500000 || fileType == .typeSymbolicLink {
                         assets.append(VideoAsset(accessibilityLabel: folderName,
                                                  id: NSUUID().uuidString,
                                                  title: lurl.lastPathComponent,


### PR DESCRIPTION
Closes: https://github.com/JohnCoates/Aerial/issues/1365
What I've done: disabled file size check for local videos, and allowed symlinks when building playlist. File size check is still run for online sources.